### PR TITLE
Add backend CI workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,51 @@
+name: Backend CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend-ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff mypy pytest pytest-cov pip-audit
+
+      - name: Ruff lint
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .
+
+      - name: mypy type check
+        run: mypy .
+
+      - name: pip audit
+        run: pip-audit
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=. --cov-report=xml --cov-fail-under=90
+
+      - name: Secret scanning
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: main
+          head: HEAD


### PR DESCRIPTION
Sets up GitHub Actions CI pipeline for the Python/FastAPI backend.

Runs automatically on every push and pull request to main. The following checks must pass before any code can be merged:

- Ruff — linting and formatting enforcement
- mypy — type annotation checking
- pip-audit — dependency vulnerability scanning
- pytest — test suite with 90% minimum coverage gate
- TruffleHog — secret scanning to prevent credentials being committed

The working directory is set to `backend/` in anticipation of the monorepo structure defined in ARCHITECTURE.md. The pipeline will report failures on any violation — no exceptions.