### PR TITLE
Add SwiftLint configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,70 @@
+# PRLifts SwiftLint Configuration
+# Enforces coding standards defined in docs/STANDARDS.md
+
+excluded:
+  - .build
+  - DerivedData
+  - Pods
+
+opt_in_rules:
+  - closure_spacing
+  - collection_alignment
+  - contains_over_filter_count
+  - empty_count
+  - explicit_init
+  - fatal_error_message
+  - first_where
+  - force_unwrapping
+  - identical_operands
+  - joined_default_parameter
+  - literal_expression_end_indentation
+  - multiline_arguments
+  - multiline_function_chains
+  - operator_usage_whitespace
+  - overridden_super_call
+  - prefer_self_type_over_type_of_self
+  - redundant_nil_coalescing
+  - sorted_imports
+  - toggle_bool
+  - unneeded_parentheses_in_closure_argument
+  - vertical_parameter_alignment_on_call
+
+disabled_rules:
+  - trailing_whitespace  # handled by Xcode automatically
+
+line_length:
+  warning: 120
+  error: 150
+
+function_body_length:
+  warning: 40
+  error: 60
+
+type_body_length:
+  warning: 300
+  error: 400
+
+file_length:
+  warning: 400
+  error: 600
+
+cyclomatic_complexity:
+  warning: 10
+  error: 15
+
+nesting:
+  type_level:
+    warning: 2
+  function_level:
+    warning: 3
+
+identifier_name:
+  min_length:
+    warning: 2
+  excluded:
+    - id
+    - pr
+    - db
+    - rpe
+    - url
+    - api


### PR DESCRIPTION
**Title:** `Add SwiftLint configuration`

**Description:**
```
Adds SwiftLint configuration file (.swiftlint.yml) to enforce iOS coding 
standards defined in docs/STANDARDS.md.

Rules configured:
- Line length: warning at 120, error at 150
- Function body length: warning at 40 lines (matches the 40-line limit 
  in STANDARDS.md), error at 60
- Cyclomatic complexity: warning at 10, error at 15
- Maximum 3 levels of nesting
- Force unwrapping flagged as a violation — use guard let or if let instead
- Sorted imports enforced for consistency

Excluded directories: .build, DerivedData, Pods

This configuration will be enforced by Xcode Cloud on every build. 
Violations at the error level will fail the build and block merging.
```