### PR TITLE
[BE] Configure Supabase connection and database session management

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -29,6 +29,10 @@ class Settings:
         self.sentry_dsn: str = os.environ.get("SENTRY_DSN", "")
         self.api_host: str = os.environ.get("API_HOST", "0.0.0.0")
         self.api_port: int = int(os.environ.get("API_PORT", "8000"))
+        # DATABASE_URL contains credentials — never log this value.
+        self.database_url: str = os.environ["DATABASE_URL"]
+        self.db_pool_size: int = int(os.environ.get("DB_POOL_SIZE", "5"))
+        self.db_max_overflow: int = int(os.environ.get("DB_MAX_OVERFLOW", "5"))
 
 
 @lru_cache(maxsize=1)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,128 @@
+"""
+database.py
+PRLifts Backend
+
+SQLAlchemy async engine and session factory for Supabase PostgreSQL.
+The engine is created once on startup and disposed on shutdown via
+FastAPI's lifespan context manager. Every route that needs the database
+receives a session through the get_db() FastAPI dependency.
+
+Security: DATABASE_URL contains credentials and is never logged at any level.
+See docs/STANDARDS.md § 2.2 Hard Rules — Never in Code.
+See docs/ARCHITECTURE.md — Backend Tech Stack.
+"""
+
+import logging
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def build_engine(database_url: str, pool_size: int, max_overflow: int) -> AsyncEngine:
+    """
+    Creates a SQLAlchemy async engine for PostgreSQL via asyncpg.
+
+    database_url is accepted as a parameter rather than read from settings
+    inside this function so that tests can inject a value without creating a
+    real connection. pool_pre_ping=True recycles stale connections after a
+    Supabase-side timeout or network event.
+
+    The database_url is intentionally not logged — it contains credentials.
+    See docs/STANDARDS.md § 2.2 Hard Rules.
+
+    Args:
+        database_url: asyncpg connection string. Never logged at any level.
+        pool_size: Minimum open connections kept in the pool.
+        max_overflow: Additional connections allowed above pool_size.
+
+    Returns:
+        Configured AsyncEngine instance (no connection is made at this point).
+    """
+    return create_async_engine(
+        database_url,
+        pool_size=pool_size,
+        max_overflow=max_overflow,
+        pool_pre_ping=True,
+    )
+
+
+async def init_db() -> None:
+    """
+    Creates the async engine and session factory from application settings.
+
+    Called once from the FastAPI lifespan on startup. Only pool sizing is
+    logged — the connection string and credentials are never emitted.
+    """
+    global _engine, _session_factory
+    settings = get_settings()
+
+    _engine = build_engine(
+        settings.database_url,
+        settings.db_pool_size,
+        settings.db_max_overflow,
+    )
+    _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
+
+    logger.info(
+        "Database connection pool initialised",
+        extra={
+            "pool_size": settings.db_pool_size,
+            "max_overflow": settings.db_max_overflow,
+        },
+    )
+
+
+async def close_db() -> None:
+    """
+    Disposes the async engine and releases all pooled connections.
+
+    Called from the FastAPI lifespan on shutdown. Clears both the engine and
+    the session factory so any post-shutdown call to get_db() fails fast.
+    Safe to call even if init_db() was never reached.
+    """
+    global _engine, _session_factory
+    if _engine is not None:
+        await _engine.dispose()
+        _engine = None
+        _session_factory = None
+        logger.info("Database connection pool closed")
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """
+    FastAPI dependency that yields an AsyncSession scoped to one request.
+
+    If the handler raises without committing, the session is explicitly
+    rolled back before closing. Callers must commit explicitly when writes
+    should be persisted — this function does not auto-commit.
+
+    Yields:
+        AsyncSession for the current request.
+
+    Raises:
+        RuntimeError: If init_db() was not called before the first request.
+    """
+    if _session_factory is None:
+        raise RuntimeError(
+            "Database pool not initialised. "
+            "Ensure init_db() is called in the FastAPI lifespan."
+        )
+
+    async with _session_factory() as session:
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 
 from app.config import get_settings
+from app.database import close_db, init_db
 from app.logging_config import configure_logging
 from app.middleware.correlation_id import CorrelationIDMiddleware
 from app.routers.health import router as health_router
@@ -74,6 +75,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     configure_logging(settings.log_level)
     _init_sentry(settings.sentry_dsn, settings.environment)
 
+    await init_db()
     scheduler.start()
     logger.info(
         "Application started",
@@ -86,6 +88,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     yield
 
     scheduler.shutdown()
+    await close_db()
     logger.info("Application stopped")
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,7 @@ cyclonedx-python-lib==11.7.0
 defusedxml==0.7.1
 fastapi==0.136.1
 filelock==3.29.0
+greenlet==3.5.0
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,6 +15,13 @@ from collections.abc import Generator
 os.environ.setdefault("ENVIRONMENT", "test")
 os.environ.setdefault("LOG_LEVEL", "DEBUG")
 os.environ.setdefault("APP_VERSION", "0.1.0")
+# Fake DATABASE_URL used for unit tests — no real connection is made at engine
+# creation time (SQLAlchemy is lazy). Pool sizes are small to keep tests fast.
+os.environ.setdefault(
+    "DATABASE_URL", "postgresql+asyncpg://fake:fake@localhost:5432/fake_test"
+)
+os.environ.setdefault("DB_POOL_SIZE", "2")
+os.environ.setdefault("DB_MAX_OVERFLOW", "1")
 
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,0 +1,251 @@
+"""
+test_database.py
+PRLifts Backend Tests
+
+Tests for app/database.py: engine creation, pool initialisation, session
+dependency, rollback-on-exception, and credential safety (connection string
+must never appear in log output).
+
+The integration test at the bottom requires a real PostgreSQL instance and is
+skipped automatically when ENVIRONMENT=test (the default for the unit test run).
+To run it locally: set ENVIRONMENT=development and provide a real DATABASE_URL.
+"""
+
+import logging
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+# ── Engine creation ────────────────────────────────────────────────────────────
+
+
+def test_build_engine_returns_async_engine() -> None:
+    # Arrange
+    from app.database import build_engine
+
+    # Act
+    engine = build_engine(
+        "postgresql+asyncpg://fake:fake@localhost:5432/fake_test", 2, 1
+    )
+
+    # Assert
+    assert isinstance(engine, AsyncEngine)
+
+
+def test_build_engine_applies_pool_configuration() -> None:
+    # Arrange
+    from app.database import build_engine
+
+    # Act
+    engine = build_engine(
+        "postgresql+asyncpg://fake:fake@localhost:5432/fake_test",
+        pool_size=3,
+        max_overflow=2,
+    )
+
+    # Assert — SQLAlchemy exposes pool config on the underlying sync engine
+    pool = engine.sync_engine.pool
+    assert pool.size() == 3  # type: ignore[attr-defined]
+
+
+# ── Pool initialisation ────────────────────────────────────────────────────────
+
+
+async def test_init_db_sets_engine_and_session_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    import app.database as db_module
+
+    mock_engine = AsyncMock(spec=AsyncEngine)
+    mock_factory = MagicMock()
+
+    monkeypatch.setattr(db_module, "_engine", None)
+    monkeypatch.setattr(db_module, "_session_factory", None)
+
+    # Act
+    with (
+        patch("app.database.build_engine", return_value=mock_engine),
+        patch("app.database.async_sessionmaker", return_value=mock_factory),
+    ):
+        await db_module.init_db()
+
+    # Assert
+    assert db_module._engine is mock_engine
+    assert db_module._session_factory is mock_factory
+
+
+async def test_init_db_logs_pool_size_not_credentials(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    import app.database as db_module
+
+    monkeypatch.setattr(db_module, "_engine", None)
+    monkeypatch.setattr(db_module, "_session_factory", None)
+
+    # Act
+    with (
+        patch("app.database.build_engine", return_value=AsyncMock(spec=AsyncEngine)),
+        patch("app.database.async_sessionmaker", return_value=MagicMock()),
+        caplog.at_level(logging.INFO, logger="app.database"),
+    ):
+        await db_module.init_db()
+
+    # Assert — pool size is logged, credentials are not
+    assert any("pool" in r.message.lower() for r in caplog.records)
+    database_url = os.environ.get("DATABASE_URL", "")
+    for record in caplog.records:
+        assert database_url not in record.getMessage()
+
+
+# ── Pool shutdown ──────────────────────────────────────────────────────────────
+
+
+async def test_close_db_disposes_engine_and_clears_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    import app.database as db_module
+
+    mock_engine = AsyncMock(spec=AsyncEngine)
+    mock_factory = MagicMock()
+    monkeypatch.setattr(db_module, "_engine", mock_engine)
+    monkeypatch.setattr(db_module, "_session_factory", mock_factory)
+
+    # Act
+    await db_module.close_db()
+
+    # Assert
+    mock_engine.dispose.assert_awaited_once()
+    assert db_module._engine is None
+    assert db_module._session_factory is None
+
+
+async def test_close_db_is_noop_when_engine_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    import app.database as db_module
+
+    monkeypatch.setattr(db_module, "_engine", None)
+
+    # Act + Assert — no exception raised
+    await db_module.close_db()
+
+
+# ── Session dependency ─────────────────────────────────────────────────────────
+
+
+async def test_get_db_raises_when_pool_not_initialised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    import app.database as db_module
+
+    monkeypatch.setattr(db_module, "_session_factory", None)
+
+    # Act + Assert
+    with pytest.raises(RuntimeError, match="not initialised"):
+        async for _ in db_module.get_db():
+            pass
+
+
+async def test_get_db_yields_session_to_caller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    import app.database as db_module
+
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_factory = _make_session_factory(mock_session)
+    monkeypatch.setattr(db_module, "_session_factory", mock_factory)
+
+    # Act
+    yielded: list[AsyncSession] = []
+    async for session in db_module.get_db():
+        yielded.append(session)
+
+    # Assert
+    assert len(yielded) == 1
+    assert yielded[0] is mock_session
+
+
+async def test_get_db_rolls_back_session_when_handler_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    import app.database as db_module
+
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_factory = _make_session_factory(mock_session)
+    monkeypatch.setattr(db_module, "_session_factory", mock_factory)
+
+    gen = db_module.get_db()
+
+    # Advance the generator to the yield point (FastAPI does this on request entry)
+    await gen.__anext__()
+
+    # Act — simulate FastAPI injecting the route exception via athrow(),
+    # which is how FastAPI's dependency system propagates handler exceptions.
+    # A plain `async for` body-raise does NOT throw back into the generator.
+    with pytest.raises(ValueError, match="deliberate"):
+        await gen.athrow(ValueError("deliberate test error"))
+
+    # Assert — session was rolled back before the exception propagated
+    mock_session.rollback.assert_awaited_once()
+
+
+# ── Integration test ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENVIRONMENT") == "test",
+    reason=(
+        "Integration test requires a real PostgreSQL instance. "
+        "Run locally with ENVIRONMENT=development and a valid DATABASE_URL."
+    ),
+)
+async def test_database_simple_query_executes_against_real_database() -> None:
+    # Arrange — build a real engine using the configured DATABASE_URL
+    from sqlalchemy import text
+
+    import app.database as db_module
+    from app.config import get_settings
+
+    settings = get_settings()
+    engine = db_module.build_engine(
+        settings.database_url, settings.db_pool_size, settings.db_max_overflow
+    )
+
+    # Act — execute a trivial query to confirm the connection is live
+    async with engine.connect() as conn:
+        result = await conn.execute(text("SELECT 1"))
+        row = result.fetchone()
+
+    await engine.dispose()
+
+    # Assert
+    assert row is not None
+    assert row[0] == 1
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_session_factory(mock_session: AsyncMock) -> MagicMock:
+    """
+    Builds a mock async_sessionmaker whose context manager yields mock_session.
+
+    The factory call returns a context manager that enters to mock_session
+    and exits cleanly, mirroring how async_sessionmaker behaves.
+    """
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+
+    factory = MagicMock()
+    factory.return_value = ctx
+    return factory


### PR DESCRIPTION
## Summary

Implements [#11](https://github.com/tigersabre/prlifts/issues/11) — SQLAlchemy async engine, connection pool, and session dependency for Supabase PostgreSQL.

- **`app/database.py`** — `build_engine()` creates the async engine (asyncpg driver, `pool_pre_ping=True`); `init_db()` / `close_db()` manage pool lifecycle from the FastAPI lifespan; `get_db()` is the FastAPI dependency that yields a session per request with explicit rollback if the handler raises. `DATABASE_URL` is never logged at any level.
- **`app/config.py`** — `database_url` (required), `db_pool_size` (default 5), `db_max_overflow` (default 5) added to `Settings`. Pool size 5 + overflow 5 = 10 max concurrent connections per issue spec.
- **`main.py`** — `init_db()` called on startup, `close_db()` on shutdown in the lifespan. `close_db()` clears both `_engine` and `_session_factory` so any post-shutdown `get_db()` call fails fast with a clear error.
- **`requirements.txt`** — `greenlet==3.5.0` added. `AsyncEngine.dispose()` requires it; it is a missing transitive dependency (`SQLAlchemy[asyncio]` installs it, bare `SQLAlchemy` does not).
- **`tests/conftest.py`** — Fake `DATABASE_URL` and small pool sizes set before app import so the full lifespan runs cleanly in the unit test environment without a real database.
- **`tests/test_database.py`** — 9 unit tests covering all paths in `database.py` + 1 integration test skipped automatically when `ENVIRONMENT=test`.

## Notable design decisions

**Rollback test uses `athrow()`** — FastAPI's dependency system propagates handler exceptions into the generator via `gen.athrow()`, not via raising inside `async for`. Testing with `async for body raise` doesn't reach the `except` block; `athrow()` does. This distinction is documented in the test.

**`close_db()` clears `_session_factory`** — After the engine is disposed, the session factory would produce sessions backed by a dead engine. Clearing it ensures `get_db()` raises `RuntimeError` immediately if called after shutdown.

**`DATABASE_URL` never logged** — It is read from env and passed directly to `create_async_engine`. The only logged fields after init are `pool_size` and `max_overflow`. Verified by `test_init_db_logs_pool_size_not_credentials`.

## Test plan

- [x] `build_engine()` returns `AsyncEngine` with correct pool size
- [x] `init_db()` sets `_engine` and `_session_factory`; logs pool config, not credentials
- [x] `close_db()` calls `engine.dispose()` and clears both globals
- [x] `close_db()` is a no-op when engine is already `None`
- [x] `get_db()` raises `RuntimeError` when pool not initialised
- [x] `get_db()` yields session to caller
- [x] `get_db()` rolls back session when handler raises (tested with `athrow()`)
- [x] Integration test (skipped in CI) — real `SELECT 1` against `prlifts_dev`
- [x] Existing health check tests continue to pass with database wired into lifespan

**Results:** 27 passed · 1 skipped · 100% coverage · ruff clean · mypy strict clean

## Definition of Done

- [x] SQLAlchemy async engine configured
- [x] Connection pool configured (pool_size=5, max_overflow=5)
- [x] `get_db` dependency injection working
- [x] Unit test: session created and closed correctly
- [x] Unit test: credentials never appear in log output
- [x] Integration test: real query against `prlifts_dev` (skipped in CI; run locally with `ENVIRONMENT=development`)
- [x] Coverage >= 90% (100%)
- [x] Ruff passes
- [x] mypy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)