### PR TITLE
Fix TruffleHog BASE==HEAD failure on push to main

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -54,8 +54,23 @@ jobs:
         run: pytest
 
       - name: Secret scanning
+        # Use concrete SHA pairs from the event payload rather than branch names.
+        # Branch names (e.g. "main") resolve to the same commit as HEAD the moment
+        # a merge lands, making BASE == HEAD and causing TruffleHog to abort.
+        #
+        # pull_request: scan the exact diff the PR introduces (base sha → head sha).
+        # push:         scan commits added by this push (before sha → pushed sha).
+        #
+        # The step is skipped on the first push to a new branch because
+        # github.event.before is all-zeros — there is no previous commit to diff
+        # against, and the PR scan will cover those commits when a PR is opened.
+        if: >-
+          github.event_name == 'pull_request' ||
+          (github.event_name == 'push' &&
+          github.event.before != '0000000000000000000000000000000000000000' &&
+          github.event.before != github.sha)
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: main
-          head: HEAD
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
## Problem

TruffleHog was configured with `base: main` and `head: HEAD`. When a PR merges into main and the push event fires, both of those refs resolve to the same commit — the merge commit is now the tip of `main`, so `base == head` and TruffleHog aborts with _"BASE and HEAD commits are the same. TruffleHog won't scan anything."_

## Fix

Replace static branch names with concrete SHA pairs sourced from the GitHub event payload, and add a guard condition so the step only runs when there is an actual diff to scan.

| Event | base | head |
|---|---|---|
| `pull_request` | `github.event.pull_request.base.sha` | `github.event.pull_request.head.sha` |
| `push` | `github.event.before` | `github.sha` |

**Guard condition** — the step is skipped when:
- `github.event.before` is all-zeros (first push to a new branch — no prior commit exists to diff against; the PR scan covers those commits when the PR is opened)
- `github.event.before == github.sha` (defensive check; shouldn't occur in practice but prevents a repeat of the original failure mode)

## Behaviour after fix

| Scenario | Before | After |
|---|---|---|
| PR opened / updated | ✅ scanned (wrong SHAs, but happened to work) | ✅ scanned with exact PR diff |
| Push to main after merge | ❌ TruffleHog aborts (BASE == HEAD) | ✅ scans commits added by the merge push |
| First push to new branch | ✅ scanned | ⏭ skipped (PR scan covers it) |
| Subsequent push to feature branch | ✅ scanned | ✅ scanned (before → sha) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)