### PR TITLE
[BE] Implement Supabase Auth middleware

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,137 @@
+"""
+auth.py
+PRLifts Backend
+
+FastAPI dependency for Supabase JWT authentication. get_current_user is the
+single entry point for protected routes — add it as a Depends() parameter to
+any route that requires a signed-in user.
+
+The JWT value is never logged at any level. Only the resolved user_id is logged
+on successful authentication. See docs/STANDARDS.md § 2.2 Hard Rules.
+See docs/ERROR_CATALOG.md — Auth Errors for all error codes used here.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import NoReturn
+from uuid import UUID
+
+import jwt
+from fastapi import HTTPException, Request, status
+
+from app.config import get_settings
+from app.schemas import ErrorResponse
+
+logger = logging.getLogger(__name__)
+
+_ALGORITHM = "HS256"
+_AUDIENCE = "authenticated"
+
+
+@dataclass(frozen=True)
+class AuthenticatedUser:
+    """
+    Validated user identity extracted from a Supabase JWT.
+
+    Returned by get_current_user on success. The id maps to auth.uid() in
+    PostgreSQL RLS policies and to the user.id primary key.
+    """
+
+    id: UUID
+    role: str
+
+
+def _raise_401(error_code: str, message: str, correlation_id: str) -> NoReturn:
+    """
+    Raises HTTP 401 with a standard ErrorResponse body.
+
+    Args:
+        error_code: Machine-readable code from docs/ERROR_CATALOG.md.
+        message: User-safe message. Never include internal details.
+        correlation_id: Request correlation ID for support queries.
+
+    Raises:
+        HTTPException: Always — HTTP 401 with the error body.
+    """
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=ErrorResponse(
+            error_code=error_code,
+            message=message,
+            request_id=correlation_id,
+        ).model_dump(),
+    )
+
+
+async def get_current_user(request: Request) -> AuthenticatedUser:
+    """
+    FastAPI dependency that validates a Supabase JWT and returns the caller's identity.
+
+    Reads Authorization: Bearer <token>, decodes with SUPABASE_JWT_SECRET using
+    HS256, and returns the authenticated user from the token claims.
+
+    The raw JWT is never logged — only the resolved user_id is emitted on success.
+
+    Args:
+        request: The incoming FastAPI request.
+
+    Returns:
+        AuthenticatedUser with the validated user id and role.
+
+    Raises:
+        HTTPException 401 auth_token_missing: No Authorization header present.
+        HTTPException 401 auth_token_expired: JWT is past its expiry time.
+        HTTPException 401 auth_token_invalid: Signature invalid, malformed token,
+            bad audience, or sub claim missing/non-UUID.
+    """
+    correlation_id: str = getattr(request.state, "correlation_id", "")
+
+    auth_header: str = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        _raise_401("auth_token_missing", "Authentication required.", correlation_id)
+
+    token = auth_header.removeprefix("Bearer ")
+    secret = get_settings().supabase_jwt_secret
+
+    try:
+        payload: dict[str, object] = jwt.decode(
+            token,
+            secret,
+            algorithms=[_ALGORITHM],
+            audience=_AUDIENCE,
+        )
+    except jwt.ExpiredSignatureError:
+        # Caught before InvalidTokenError because ExpiredSignatureError is a subclass.
+        _raise_401(
+            "auth_token_expired",
+            "Your session has expired. Please sign in again.",
+            correlation_id,
+        )
+    except jwt.InvalidTokenError:
+        _raise_401(
+            "auth_token_invalid",
+            "Your session has expired. Please sign in again.",
+            correlation_id,
+        )
+
+    sub = payload.get("sub")
+    if not isinstance(sub, str) or not sub:
+        _raise_401(
+            "auth_token_invalid",
+            "Your session has expired. Please sign in again.",
+            correlation_id,
+        )
+
+    try:
+        user_id = UUID(sub)
+    except ValueError:
+        _raise_401(
+            "auth_token_invalid",
+            "Your session has expired. Please sign in again.",
+            correlation_id,
+        )
+
+    role: str = str(payload.get("role", _AUDIENCE))
+
+    logger.info("User authenticated", extra={"user_id": str(user_id)})
+    return AuthenticatedUser(id=user_id, role=role)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -29,6 +29,8 @@ class Settings:
         self.sentry_dsn: str = os.environ.get("SENTRY_DSN", "")
         self.api_host: str = os.environ.get("API_HOST", "0.0.0.0")
         self.api_port: int = int(os.environ.get("API_PORT", "8000"))
+        # Used to verify Supabase JWTs — never log this value.
+        self.supabase_jwt_secret: str = os.environ.get("SUPABASE_JWT_SECRET", "")
 
 
 @lru_cache(maxsize=1)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,30 @@
+"""
+schemas.py
+PRLifts Backend
+
+Shared Pydantic response schemas used across all API endpoints.
+Putting them here keeps routers thin and avoids circular imports —
+auth, routers, and middleware can all reference these without depending
+on each other.
+
+See docs/ERROR_CATALOG.md for all valid error codes and user-facing messages.
+See docs/STANDARDS.md § 7.5 API Error Response Standard.
+"""
+
+from pydantic import BaseModel
+
+
+class ErrorResponse(BaseModel):
+    """
+    Standard error response body for all backend error responses.
+
+    error_code is machine-readable and drives client-side behaviour (e.g. sign-out).
+    message is safe to display directly to users — never contains internal detail.
+    request_id is the correlation_id so users can quote it to support.
+
+    See docs/ERROR_CATALOG.md for every valid error_code and its matching message.
+    """
+
+    error_code: str
+    message: str
+    request_id: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,6 +44,7 @@ pyparsing==3.3.2
 pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-cov==7.1.0
+PyJWT==2.12.1
 python-dotenv==1.2.2
 redis==7.4.0
 requests==2.33.1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,6 +15,7 @@ from collections.abc import Generator
 os.environ.setdefault("ENVIRONMENT", "test")
 os.environ.setdefault("LOG_LEVEL", "DEBUG")
 os.environ.setdefault("APP_VERSION", "0.1.0")
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-supabase-jwt-secret-for-unit-tests")
 
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,335 @@
+"""
+test_auth.py
+PRLifts Backend Tests
+
+Unit tests for app/auth.py: all four JWT validation scenarios defined in
+docs/ERROR_CATALOG.md, credential safety (JWT value never in logs), and the
+shared ErrorResponse schema.
+
+get_current_user is tested by calling it directly as an async function with
+a minimal mock Request — no HTTP round-trip needed for these unit tests.
+"""
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import jwt
+import pytest
+from fastapi import HTTPException
+
+
+def _detail(exc: HTTPException) -> dict[str, str]:
+    """
+    Extracts the error detail dict from an HTTPException.
+
+    Starlette 1.0.0 annotates HTTPException.detail as str rather than Any,
+    so a single type: ignore here keeps every test assertion clean.
+    """
+    return exc.detail  # type: ignore[return-value]
+
+
+# ── Test fixtures ─────────────────────────────────────────────────────────────
+
+_SECRET: str = os.environ.get(
+    "SUPABASE_JWT_SECRET", "test-supabase-jwt-secret-for-unit-tests"
+)
+_TEST_USER_ID = "550e8400-e29b-41d4-a716-446655440000"
+_ALGORITHM = "HS256"
+_AUDIENCE = "authenticated"
+
+
+def _make_token(
+    *,
+    user_id: str | None = _TEST_USER_ID,
+    expired: bool = False,
+    audience: str = _AUDIENCE,
+    secret: str = _SECRET,
+) -> str:
+    """
+    Encodes a test JWT signed with the test secret.
+
+    Args:
+        user_id: Value for the sub claim. Pass None to omit the claim.
+        expired: If True, sets exp one hour in the past.
+        audience: Value for the aud claim.
+        secret: Signing secret (defaults to the test secret from env).
+
+    Returns:
+        Encoded JWT string.
+    """
+    now = datetime.now(UTC)
+    exp = now - timedelta(hours=1) if expired else now + timedelta(hours=1)
+    payload: dict[str, Any] = {
+        "exp": exp,
+        "aud": audience,
+        "role": "authenticated",
+    }
+    if user_id is not None:
+        payload["sub"] = user_id
+    return jwt.encode(payload, secret, algorithm=_ALGORITHM)
+
+
+def _make_request(
+    authorization: str | None = None,
+    correlation_id: str = "test-correlation-id",
+) -> MagicMock:
+    """
+    Builds a minimal mock Request for testing get_current_user directly.
+
+    Only the two attributes get_current_user reads are wired up:
+    request.headers.get("authorization", "") and request.state.correlation_id.
+
+    Args:
+        authorization: Full header value, e.g. "Bearer <token>". None omits it.
+        correlation_id: Value stored on request.state.
+
+    Returns:
+        MagicMock that behaves like a Starlette Request for auth purposes.
+    """
+    headers: dict[str, str] = {}
+    if authorization is not None:
+        headers["authorization"] = authorization
+
+    req = MagicMock()
+    req.headers.get = lambda key, default="": headers.get(key, default)
+    req.state.correlation_id = correlation_id
+    return req
+
+
+# ── Happy path ────────────────────────────────────────────────────────────────
+
+
+async def test_get_current_user_returns_authenticated_user_for_valid_jwt() -> None:
+    # Arrange
+    from app.auth import AuthenticatedUser, get_current_user
+
+    token = _make_token()
+    request = _make_request(authorization=f"Bearer {token}")
+
+    # Act
+    user = await get_current_user(request)
+
+    # Assert
+    assert isinstance(user, AuthenticatedUser)
+    assert user.id == UUID(_TEST_USER_ID)
+    assert user.role == "authenticated"
+
+
+async def test_get_current_user_user_id_matches_sub_claim() -> None:
+    # Arrange
+    from app.auth import get_current_user
+
+    other_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    token = _make_token(user_id=other_id)
+    request = _make_request(authorization=f"Bearer {token}")
+
+    # Act
+    user = await get_current_user(request)
+
+    # Assert
+    assert user.id == UUID(other_id)
+
+
+# ── Missing token ─────────────────────────────────────────────────────────────
+
+
+async def test_get_current_user_raises_401_auth_token_missing_when_no_header() -> None:
+    # Arrange
+    from app.auth import get_current_user
+
+    request = _make_request(authorization=None)
+
+    # Act + Assert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+    assert _detail(exc_info.value)["error_code"] == "auth_token_missing"
+    assert _detail(exc_info.value)["message"] == "Authentication required."
+
+
+async def test_get_current_user_raises_token_missing_when_no_bearer_prefix() -> None:
+    # Arrange — header present but not Bearer-prefixed
+    from app.auth import get_current_user
+
+    token = _make_token()
+    request = _make_request(authorization=token)  # missing "Bearer " prefix
+
+    # Act + Assert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+    assert _detail(exc_info.value)["error_code"] == "auth_token_missing"
+
+
+# ── Expired token ─────────────────────────────────────────────────────────────
+
+
+async def test_get_current_user_raises_401_auth_token_expired_for_past_exp() -> None:
+    # Arrange
+    from app.auth import get_current_user
+
+    token = _make_token(expired=True)
+    request = _make_request(authorization=f"Bearer {token}")
+
+    # Act + Assert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+    assert _detail(exc_info.value)["error_code"] == "auth_token_expired"
+    assert "expired" in _detail(exc_info.value)["message"].lower()
+
+
+# ── Invalid / malformed token ─────────────────────────────────────────────────
+
+
+async def test_get_current_user_raises_401_auth_token_invalid_for_garbage_string() -> (
+    None
+):
+    # Arrange
+    from app.auth import get_current_user
+
+    request = _make_request(authorization="Bearer not-a-real-jwt-at-all")
+
+    # Act + Assert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+    assert _detail(exc_info.value)["error_code"] == "auth_token_invalid"
+
+
+async def test_get_current_user_raises_401_auth_token_invalid_for_wrong_secret() -> (
+    None
+):
+    # Arrange — valid JWT structure but signed with a different secret
+    from app.auth import get_current_user
+
+    token = _make_token(secret="completely-different-secret-xxxxxxxxxx")
+    request = _make_request(authorization=f"Bearer {token}")
+
+    # Act + Assert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+    assert _detail(exc_info.value)["error_code"] == "auth_token_invalid"
+
+
+async def test_get_current_user_raises_401_auth_token_invalid_when_sub_is_missing() -> (
+    None
+):
+    # Arrange — valid signature but no sub claim
+    from app.auth import get_current_user
+
+    token = _make_token(user_id=None)
+    request = _make_request(authorization=f"Bearer {token}")
+
+    # Act + Assert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+    assert _detail(exc_info.value)["error_code"] == "auth_token_invalid"
+
+
+async def test_get_current_user_raises_token_invalid_when_sub_is_not_a_uuid() -> None:
+    # Arrange — sub is present but not a valid UUID
+    from app.auth import get_current_user
+
+    token = _make_token(user_id="not-a-uuid")
+    request = _make_request(authorization=f"Bearer {token}")
+
+    # Act + Assert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+    assert _detail(exc_info.value)["error_code"] == "auth_token_invalid"
+
+
+# ── Error response structure ──────────────────────────────────────────────────
+
+
+async def test_error_response_includes_correlation_id_as_request_id() -> None:
+    # Arrange
+    from app.auth import get_current_user
+
+    request = _make_request(authorization=None, correlation_id="my-correlation-id")
+
+    # Act + Assert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+
+    assert _detail(exc_info.value)["request_id"] == "my-correlation-id"
+
+
+# ── Credential safety ─────────────────────────────────────────────────────────
+
+
+async def test_get_current_user_never_logs_jwt_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Arrange
+    from app.auth import get_current_user
+
+    token = _make_token()
+    request = _make_request(authorization=f"Bearer {token}")
+
+    # Act
+    with caplog.at_level(logging.DEBUG):
+        await get_current_user(request)
+
+    # Assert — the raw JWT must not appear in any log record at any level
+    for record in caplog.records:
+        assert token not in record.getMessage()
+        assert token not in str(record.__dict__)
+
+
+async def test_get_current_user_logs_user_id_on_success(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Arrange
+    from app.auth import get_current_user
+
+    token = _make_token()
+    request = _make_request(authorization=f"Bearer {token}")
+
+    # Act
+    with caplog.at_level(logging.INFO, logger="app.auth"):
+        await get_current_user(request)
+
+    # Assert — user_id appears in logs, JWT does not
+    log_output = " ".join(r.getMessage() for r in caplog.records)
+    assert _TEST_USER_ID in log_output or any(
+        _TEST_USER_ID in str(r.__dict__) for r in caplog.records
+    )
+
+
+# ── ErrorResponse schema ──────────────────────────────────────────────────────
+
+
+def test_error_response_serialises_all_fields() -> None:
+    # Arrange
+    from app.schemas import ErrorResponse
+
+    # Act
+    response = ErrorResponse(
+        error_code="auth_token_missing",
+        message="Authentication required.",
+        request_id="abc-123",
+    )
+
+    # Assert
+    data = response.model_dump()
+    assert data == {
+        "error_code": "auth_token_missing",
+        "message": "Authentication required.",
+        "request_id": "abc-123",
+    }


### PR DESCRIPTION
## Summary

Implements [#13](https://github.com/tigersabre/prlifts/issues/13) — JWT authentication via a FastAPI dependency.

**`app/auth.py`** — `get_current_user(request: Request) -> AuthenticatedUser`

Reads `Authorization: Bearer <token>`, decodes with `SUPABASE_JWT_SECRET` using HS256 and `audience="authenticated"`, returns `AuthenticatedUser(id: UUID, role: str)` on success. Four error cases from `ERROR_CATALOG.md`:

| Scenario | Error code | HTTP |
|---|---|---|
| No header / no `Bearer ` prefix | `auth_token_missing` | 401 |
| JWT past `exp` | `auth_token_expired` | 401 |
| Bad signature, malformed, wrong audience | `auth_token_invalid` | 401 |
| `sub` missing or not a UUID | `auth_token_invalid` | 401 |

`_raise_401` returns `NoReturn` — mypy narrows the `sub: object` type to `str` after the isinstance guard without needing a cast. The raw JWT value is never logged; only `user_id` is emitted on success.

**`app/schemas.py`** — `ErrorResponse(error_code, message, request_id)` Pydantic model shared across all endpoints. Lives here (not in `auth.py`) so future routers can import it without depending on the auth module.

**JWT library** — `PyJWT==2.12.1`. `python-jose` was considered but PyJWT is more actively maintained, has no open CVEs, and HS256 needs no extras.

## Test plan

Tests call `get_current_user` directly with a minimal mock `Request` — no HTTP round-trip:

- [x] Valid JWT returns `AuthenticatedUser` with correct `id` and `role`
- [x] `sub` claim round-trips to `user.id`
- [x] No `Authorization` header → 401 `auth_token_missing`
- [x] Header without `Bearer ` prefix → 401 `auth_token_missing`
- [x] Expired token → 401 `auth_token_expired`
- [x] Garbage string → 401 `auth_token_invalid`
- [x] Valid structure, wrong signing secret → 401 `auth_token_invalid`
- [x] No `sub` claim → 401 `auth_token_invalid`
- [x] Non-UUID `sub` → 401 `auth_token_invalid`
- [x] `correlation_id` appears as `request_id` in error body
- [x] Raw JWT never appears in any log record at any level
- [x] `user_id` appears in INFO log on success
- [x] `ErrorResponse.model_dump()` produces the correct shape

**Results:** 31 passed · 100% coverage · ruff clean · mypy strict clean

## Definition of Done

- [x] `get_current_user` dependency implemented
- [x] Valid JWT returns authenticated user
- [x] Expired JWT returns 401 `auth_token_expired`
- [x] Missing JWT returns 401 `auth_token_missing`
- [x] Malformed JWT returns 401 `auth_token_invalid`
- [x] Unit tests: all four scenarios
- [x] Verified: JWT value never appears in logs
- [x] Coverage ≥ 90% (100%)
- [x] Ruff passes
- [x] mypy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)