### PR TITLE
Add Railway staging URL to ENV_CONFIG.md

### DIFF
--- a/docs/ENV_CONFIG.md
+++ b/docs/ENV_CONFIG.md
@@ -189,6 +189,13 @@ In Railway, environment variables are set per service per environment
 (staging vs production). Never share environment variables between
 the staging and production services.
 
+## Service URLs
+
+| Environment | URL |
+|---|---|
+| Staging | `https://prlifts-production.up.railway.app` |
+| Production | TBD — configured before public launch |
+
 **Setting a variable in Railway:**
 1. Select the service (PRLifts API)
 2. Variables tab


### PR DESCRIPTION
Adds the Railway staging service URL to the Railway Configuration 
section of ENV_CONFIG.md.

Staging URL: https://prlifts-production.up.railway.app

This completes issue #16 — all Railway deployment acceptance criteria 
are met:
- Railway connected to GitHub repo ✅
- Environment variables configured ✅
- Auto-deploy on main merge working ✅
- Health check returning 200 on staging URL ✅
- Deployment logs visible in Railway dashboard ✅
- Staging URL documented in ENV_CONFIG.md ✅