### PR TITLE
Add Xcode project and PRLiftsCore Swift Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ fastlane/test_output
 backend/.venv/
 backend/__pycache__/
 backend/.pytest_cache/
+backend/.coverage
+backend/**/__pycache__/
+backend/.pytest_cache/

--- a/PRLifts/PRLifts.xcodeproj/project.pbxproj
+++ b/PRLifts/PRLifts.xcodeproj/project.pbxproj
@@ -1,0 +1,606 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A47327AF2FA17E2C009B2BC7 /* PRLiftsCore in Frameworks */ = {isa = PBXBuildFile; productRef = A47327AE2FA17E2C009B2BC7 /* PRLiftsCore */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A47327902FA066AE009B2BC7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A473277A2FA066AD009B2BC7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A47327812FA066AD009B2BC7;
+			remoteInfo = PRLifts;
+		};
+		A473279A2FA066AE009B2BC7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A473277A2FA066AD009B2BC7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A47327812FA066AD009B2BC7;
+			remoteInfo = PRLifts;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A47327822FA066AD009B2BC7 /* PRLifts.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PRLifts.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A473278F2FA066AE009B2BC7 /* PRLiftsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PRLiftsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A47327992FA066AE009B2BC7 /* PRLiftsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PRLiftsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A47327AC2FA17D00009B2BC7 /* PRLiftsCore */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = PRLiftsCore; path = ../PRLiftsCore; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A47327842FA066AD009B2BC7 /* PRLifts */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = PRLifts;
+			sourceTree = "<group>";
+		};
+		A47327922FA066AE009B2BC7 /* PRLiftsTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = PRLiftsTests;
+			sourceTree = "<group>";
+		};
+		A473279C2FA066AE009B2BC7 /* PRLiftsUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = PRLiftsUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A473277F2FA066AD009B2BC7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A47327AF2FA17E2C009B2BC7 /* PRLiftsCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A473278C2FA066AE009B2BC7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A47327962FA066AE009B2BC7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A47327792FA066AD009B2BC7 = {
+			isa = PBXGroup;
+			children = (
+				A47327AC2FA17D00009B2BC7 /* PRLiftsCore */,
+				A47327842FA066AD009B2BC7 /* PRLifts */,
+				A47327922FA066AE009B2BC7 /* PRLiftsTests */,
+				A473279C2FA066AE009B2BC7 /* PRLiftsUITests */,
+				A47327AD2FA17E2C009B2BC7 /* Frameworks */,
+				A47327832FA066AD009B2BC7 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A47327832FA066AD009B2BC7 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A47327822FA066AD009B2BC7 /* PRLifts.app */,
+				A473278F2FA066AE009B2BC7 /* PRLiftsTests.xctest */,
+				A47327992FA066AE009B2BC7 /* PRLiftsUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A47327AD2FA17E2C009B2BC7 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A47327812FA066AD009B2BC7 /* PRLifts */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A47327A32FA066AE009B2BC7 /* Build configuration list for PBXNativeTarget "PRLifts" */;
+			buildPhases = (
+				A473277E2FA066AD009B2BC7 /* Sources */,
+				A473277F2FA066AD009B2BC7 /* Frameworks */,
+				A47327802FA066AD009B2BC7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A47327842FA066AD009B2BC7 /* PRLifts */,
+			);
+			name = PRLifts;
+			packageProductDependencies = (
+				A47327AE2FA17E2C009B2BC7 /* PRLiftsCore */,
+			);
+			productName = PRLifts;
+			productReference = A47327822FA066AD009B2BC7 /* PRLifts.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A473278E2FA066AE009B2BC7 /* PRLiftsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A47327A62FA066AE009B2BC7 /* Build configuration list for PBXNativeTarget "PRLiftsTests" */;
+			buildPhases = (
+				A473278B2FA066AE009B2BC7 /* Sources */,
+				A473278C2FA066AE009B2BC7 /* Frameworks */,
+				A473278D2FA066AE009B2BC7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A47327912FA066AE009B2BC7 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A47327922FA066AE009B2BC7 /* PRLiftsTests */,
+			);
+			name = PRLiftsTests;
+			packageProductDependencies = (
+			);
+			productName = PRLiftsTests;
+			productReference = A473278F2FA066AE009B2BC7 /* PRLiftsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		A47327982FA066AE009B2BC7 /* PRLiftsUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A47327A92FA066AE009B2BC7 /* Build configuration list for PBXNativeTarget "PRLiftsUITests" */;
+			buildPhases = (
+				A47327952FA066AE009B2BC7 /* Sources */,
+				A47327962FA066AE009B2BC7 /* Frameworks */,
+				A47327972FA066AE009B2BC7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A473279B2FA066AE009B2BC7 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A473279C2FA066AE009B2BC7 /* PRLiftsUITests */,
+			);
+			name = PRLiftsUITests;
+			packageProductDependencies = (
+			);
+			productName = PRLiftsUITests;
+			productReference = A47327992FA066AE009B2BC7 /* PRLiftsUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A473277A2FA066AD009B2BC7 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2630;
+				LastUpgradeCheck = 2630;
+				TargetAttributes = {
+					A47327812FA066AD009B2BC7 = {
+						CreatedOnToolsVersion = 26.3;
+					};
+					A473278E2FA066AE009B2BC7 = {
+						CreatedOnToolsVersion = 26.3;
+						TestTargetID = A47327812FA066AD009B2BC7;
+					};
+					A47327982FA066AE009B2BC7 = {
+						CreatedOnToolsVersion = 26.3;
+						TestTargetID = A47327812FA066AD009B2BC7;
+					};
+				};
+			};
+			buildConfigurationList = A473277D2FA066AD009B2BC7 /* Build configuration list for PBXProject "PRLifts" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A47327792FA066AD009B2BC7;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = A47327832FA066AD009B2BC7 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A47327812FA066AD009B2BC7 /* PRLifts */,
+				A473278E2FA066AE009B2BC7 /* PRLiftsTests */,
+				A47327982FA066AE009B2BC7 /* PRLiftsUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A47327802FA066AD009B2BC7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A473278D2FA066AE009B2BC7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A47327972FA066AE009B2BC7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A473277E2FA066AD009B2BC7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A473278B2FA066AE009B2BC7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A47327952FA066AE009B2BC7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A47327912FA066AE009B2BC7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A47327812FA066AD009B2BC7 /* PRLifts */;
+			targetProxy = A47327902FA066AE009B2BC7 /* PBXContainerItemProxy */;
+		};
+		A473279B2FA066AE009B2BC7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A47327812FA066AD009B2BC7 /* PRLifts */;
+			targetProxy = A473279A2FA066AE009B2BC7 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A47327A12FA066AE009B2BC7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 5R3A23MRJW;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A47327A22FA066AE009B2BC7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 5R3A23MRJW;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A47327A42FA066AE009B2BC7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5R3A23MRJW;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.prlifts.PRLifts;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A47327A52FA066AE009B2BC7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5R3A23MRJW;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.prlifts.PRLifts;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		A47327A72FA066AE009B2BC7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5R3A23MRJW;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.prlifts.PRLiftsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PRLifts.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PRLifts";
+			};
+			name = Debug;
+		};
+		A47327A82FA066AE009B2BC7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5R3A23MRJW;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.prlifts.PRLiftsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PRLifts.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PRLifts";
+			};
+			name = Release;
+		};
+		A47327AA2FA066AE009B2BC7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5R3A23MRJW;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.prlifts.PRLiftsUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = PRLifts;
+			};
+			name = Debug;
+		};
+		A47327AB2FA066AE009B2BC7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5R3A23MRJW;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.prlifts.PRLiftsUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = PRLifts;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A473277D2FA066AD009B2BC7 /* Build configuration list for PBXProject "PRLifts" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A47327A12FA066AE009B2BC7 /* Debug */,
+				A47327A22FA066AE009B2BC7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A47327A32FA066AE009B2BC7 /* Build configuration list for PBXNativeTarget "PRLifts" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A47327A42FA066AE009B2BC7 /* Debug */,
+				A47327A52FA066AE009B2BC7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A47327A62FA066AE009B2BC7 /* Build configuration list for PBXNativeTarget "PRLiftsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A47327A72FA066AE009B2BC7 /* Debug */,
+				A47327A82FA066AE009B2BC7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A47327A92FA066AE009B2BC7 /* Build configuration list for PBXNativeTarget "PRLiftsUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A47327AA2FA066AE009B2BC7 /* Debug */,
+				A47327AB2FA066AE009B2BC7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A47327AE2FA17E2C009B2BC7 /* PRLiftsCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PRLiftsCore;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = A473277A2FA066AD009B2BC7 /* Project object */;
+}

--- a/PRLifts/PRLifts.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/PRLifts/PRLifts.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/PRLifts/PRLifts/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/PRLifts/PRLifts/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PRLifts/PRLifts/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/PRLifts/PRLifts/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PRLifts/PRLifts/Assets.xcassets/Contents.json
+++ b/PRLifts/PRLifts/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PRLifts/PRLifts/ContentView.swift
+++ b/PRLifts/PRLifts/ContentView.swift
@@ -1,0 +1,24 @@
+//
+//  ContentView.swift
+//  PRLifts
+//
+//  Created by Sarosh Arunkumar on 4/27/26.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/PRLifts/PRLifts/PRLiftsApp.swift
+++ b/PRLifts/PRLifts/PRLiftsApp.swift
@@ -1,0 +1,17 @@
+//
+//  PRLiftsApp.swift
+//  PRLifts
+//
+//  Created by Sarosh Arunkumar on 4/27/26.
+//
+
+import SwiftUI
+
+@main
+struct PRLiftsApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/PRLifts/PRLiftsTests/PRLiftsTests.swift
+++ b/PRLifts/PRLiftsTests/PRLiftsTests.swift
@@ -1,0 +1,36 @@
+//
+//  PRLiftsTests.swift
+//  PRLiftsTests
+//
+//  Created by Sarosh Arunkumar on 4/27/26.
+//
+
+import XCTest
+@testable import PRLifts
+
+final class PRLiftsTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/PRLifts/PRLiftsUITests/PRLiftsUITests.swift
+++ b/PRLifts/PRLiftsUITests/PRLiftsUITests.swift
@@ -1,0 +1,41 @@
+//
+//  PRLiftsUITests.swift
+//  PRLiftsUITests
+//
+//  Created by Sarosh Arunkumar on 4/27/26.
+//
+
+import XCTest
+
+final class PRLiftsUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/PRLifts/PRLiftsUITests/PRLiftsUITestsLaunchTests.swift
+++ b/PRLifts/PRLiftsUITests/PRLiftsUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  PRLiftsUITestsLaunchTests.swift
+//  PRLiftsUITests
+//
+//  Created by Sarosh Arunkumar on 4/27/26.
+//
+
+import XCTest
+
+final class PRLiftsUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/PRLiftsCore/.gitignore
+++ b/PRLiftsCore/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/PRLiftsCore/Package.swift
+++ b/PRLiftsCore/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PRLiftsCore",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "PRLiftsCore",
+            targets: ["PRLiftsCore"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "PRLiftsCore"
+        ),
+        .testTarget(
+            name: "PRLiftsCoreTests",
+            dependencies: ["PRLiftsCore"]
+        ),
+    ]
+)

--- a/PRLiftsCore/Sources/PRLiftsCore/PRLiftsCore.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/PRLiftsCore.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/PRLiftsCoreTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/PRLiftsCoreTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import PRLiftsCore
+
+final class PRLiftsCoreTests: XCTestCase {
+    func testExample() throws {
+        // XCTest Documentation
+        // https://developer.apple.com/documentation/xctest
+
+        // Defining Test Cases and Test Methods
+        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    }
+}


### PR DESCRIPTION
Creates the iOS app Xcode project and Core Library Swift Package.

Structure:
- PRLifts/ — iOS app Xcode project (SwiftUI, Swift Testing + XCTest UI Tests)
- PRLiftsCore/ — Swift Package for the Core Library (shared models, 
  business logic, sync engine)

PRLiftsCore is linked to the PRLifts app target via Frameworks, 
Libraries, and Embedded Content. Project builds cleanly with zero 
warnings.

Also fixes .gitignore to exclude backend/__pycache__/ and 
backend/.coverage which were previously untracked.

Part of issue #7 — Xcode project setup. Xcode Cloud configuration 
follows in issue #8.