### PR TITLE
Migration 20260428_002: add idx_workout_set_exercise_user

### DIFF
--- a/backend/migrations/versions/20260428_002_add_pr_recalculation_index.py
+++ b/backend/migrations/versions/20260428_002_add_pr_recalculation_index.py
@@ -54,6 +54,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        sa.text("DROP INDEX IF EXISTS idx_workout_set_exercise_user")
-    )
+    op.execute(sa.text("DROP INDEX IF EXISTS idx_workout_set_exercise_user"))

--- a/backend/migrations/versions/20260428_002_add_pr_recalculation_index.py
+++ b/backend/migrations/versions/20260428_002_add_pr_recalculation_index.py
@@ -1,0 +1,59 @@
+"""Add idx_workout_set_exercise_user for cross-workout PR recalculation.
+
+PR recalculation on set edit or delete scans ALL historical WorkoutSets for
+a given exercise across every workout for a user (Decision 87). The existing
+idx_workout_set_pr_detection index covers per-set-completion PR detection but
+not the broader cross-workout historical scan triggered by an edit or delete.
+
+This index covers:
+    SELECT ws.*
+    FROM workout_set ws
+    JOIN workout_exercise we ON we.id = ws.workout_exercise_id
+    JOIN workout w ON w.id = we.workout_id
+    WHERE we.exercise_id = :exercise_id
+      AND w.user_id = :user_id
+
+Without it the recalculation performs a sequential scan of all workout_set rows.
+
+Revision ID: 20260428_002
+Revises: 20260427_001
+Create Date: 2026-04-28
+
+Reference: docs/SCHEMA.md § Indexes
+Reference: docs/ARCHITECTURE.md Decision 87, Decision 88
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260428_002"
+down_revision: str | None = "20260427_001"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text("""
+        CREATE INDEX idx_workout_set_exercise_user
+            ON workout_set(workout_exercise_id)
+    """)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("DROP INDEX IF EXISTS idx_workout_set_exercise_user")
+    )


### PR DESCRIPTION
## Summary

- Adds `20260428_002_add_pr_recalculation_index.py` — an Alembic migration that creates `idx_workout_set_exercise_user ON workout_set(workout_exercise_id)`
- Index documented in SCHEMA.md (PR #29) for cross-workout PR recalculation (Decision 87)

## Why this index

PR recalculation on set edit or delete scans **all** `WorkoutSet` rows for a given exercise across **all** workouts for a user — not just the edited workout. The existing `idx_workout_set_pr_detection` only covers the per-set-completion PR detection path. Without this index, the recalculation is a sequential scan of the full `workout_set` table.

## File naming note

The requested filename was `20260428_002_add_pr_recalculation_index.sql`. Alembic requires Python migration files — the actual file is `20260428_002_add_pr_recalculation_index.py`, consistent with the existing `20260427_001_v1_schema.py` convention.

## Test plan

Tested against local `prlifts_dev`:

- [x] `alembic upgrade head` from `20260427_001` → applies cleanly
- [x] `pg_indexes` confirms `idx_workout_set_exercise_user` present after upgrade
- [x] `alembic downgrade -1` → removes index cleanly (`DROP INDEX IF EXISTS`)
- [x] `pg_indexes` confirms index absent after downgrade
- [x] `alembic upgrade head` re-apply after downgrade → re-creates index correctly
- [x] `alembic current` confirms dev DB left at `20260428_002 (head)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)