### PR TITLE
Add Claude Design handoff bundle for sprint 1 screens

### DIFF
--- a/design/8 Screens.html
+++ b/design/8 Screens.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PRLifts — 11 Screens × Dark &amp; Light</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="screens/screens-shared.jsx"></script>
+<script type="text/babel" src="screens/screens-onboarding.jsx"></script>
+<script type="text/babel" src="screens/screens-core.jsx"></script>
+<script type="text/babel" src="screens/screens-extra.jsx"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; background: #06070F; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+
+// Wrapper: puts a Screen inside a Phone chrome
+function S({ Screen, t, ...props }) {
+  return <Phone t={t}><Screen t={t} {...props} /></Phone>;
+}
+
+function App() {
+  return (
+    <DesignCanvas
+      title="PRLifts — 11 Screens"
+      subtitle="Hybrid direction v2.0 · All screens in dark (gym) and light (outdoor) mode · Click any artboard to fullscreen"
+    >
+      {/* ── Phase 1 Onboarding ──────────────────────────────────── */}
+      <DCSection id="welcome" title="01 WelcomeScreen"
+        subtitle="App intro — value proposition, benefit bullets, Get started CTA · /onboarding/welcome">
+        <DCArtboard id="welcome-dark"  label="Dark mode"  width={390} height={844}><S Screen={WelcomeScreen}  t={DK}/></DCArtboard>
+        <DCArtboard id="welcome-light" label="Light mode" width={390} height={844}><S Screen={WelcomeScreen}  t={LT}/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="signin" title="02 SignInScreen"
+        subtitle="Sign in with Apple, Google, email · Error state shown · /onboarding/sign-in">
+        <DCArtboard id="signin-dark"  label="Dark mode"  width={390} height={844}><S Screen={SignInScreen}    t={DK}/></DCArtboard>
+        <DCArtboard id="signin-light" label="Light mode" width={390} height={844}><S Screen={SignInScreen}    t={LT}/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="displayname" title="03 DisplayNameScreen"
+        subtitle="Name entry · Focused input state · Progress step 3 of 4 · /onboarding/display-name">
+        <DCArtboard id="dn-dark"  label="Dark mode"  width={390} height={844}><S Screen={DisplayNameScreen}  t={DK}/></DCArtboard>
+        <DCArtboard id="dn-light" label="Light mode" width={390} height={844}><S Screen={DisplayNameScreen}  t={LT}/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="units" title="04 UnitPreferenceScreen"
+        subtitle="Weight (lbs/kg) + height (in/cm) · Large selection cards · US default · /onboarding/units">
+        <DCArtboard id="units-dark"  label="Dark mode"  width={390} height={844}><S Screen={UnitsScreen}      t={DK}/></DCArtboard>
+        <DCArtboard id="units-light" label="Light mode" width={390} height={844}><S Screen={UnitsScreen}      t={LT}/></DCArtboard>
+      </DCSection>
+
+      {/* ── Core App Screens ────────────────────────────────────── */}
+      <DCSection id="home" title="05 HomeScreen"
+        subtitle="Dashboard · 7-day streak, start workout CTA, recent PR cards, stat tiles · /home">
+        <DCArtboard id="home-dark"  label="Dark mode"  width={390} height={844}><S Screen={HomeScreen}        t={DK}/></DCArtboard>
+        <DCArtboard id="home-light" label="Light mode" width={390} height={844}><S Screen={HomeScreen}        t={LT}/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="active" title="06 ActiveWorkoutScreen"
+        subtitle="Set logging · PR banner active, 3 sets logged, set 4 input ready, Demo button → screen 09 · /workout/active">
+        <DCArtboard id="active-dark"  label="Dark mode"  width={390} height={844}><S Screen={ActiveWorkoutScreen}  t={DK}/></DCArtboard>
+        <DCArtboard id="active-light" label="Light mode" width={390} height={844}><S Screen={ActiveWorkoutScreen}  t={LT}/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="summary" title="07 WorkoutSummaryScreen"
+        subtitle="Post-workout · Gold PR celebration gradient, stats grid, AI insight, Done CTA · /workout/complete">
+        <DCArtboard id="summary-dark"  label="Dark mode"  width={390} height={844}><S Screen={WorkoutSummaryScreen} t={DK}/></DCArtboard>
+        <DCArtboard id="summary-light" label="Light mode" width={390} height={844}><S Screen={WorkoutSummaryScreen} t={LT}/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="prdetail" title="08 PRDetailScreen"
+        subtitle="PR detail · 225 lbs Bench Press, delta from previous, 5-bar progression chart · /records/detail/{id}">
+        <DCArtboard id="pr-dark"  label="Dark mode"  width={390} height={844}><S Screen={PRDetailScreen}     t={DK}/></DCArtboard>
+        <DCArtboard id="pr-light" label="Light mode" width={390} height={844}><S Screen={PRDetailScreen}     t={LT}/></DCArtboard>
+      </DCSection>
+
+      {/* ── New Screens ─────────────────────────────────────────── */}
+      <DCSection id="exercise" title="09 ExerciseDetailScreen"
+        subtitle="Exercise detail · ExerciseDB video player + muscle diagram fallback · Contextual CTA · /exercises/detail/{id}">
+        <DCArtboard id="ex-dark-video"  label="Dark · Video player"       width={390} height={844}><S Screen={ExerciseDetailScreen} t={DK} videoError={false}/></DCArtboard>
+        <DCArtboard id="ex-dark-error"  label="Dark · Video error fallback" width={390} height={844}><S Screen={ExerciseDetailScreen} t={DK} videoError={true}/></DCArtboard>
+        <DCArtboard id="ex-light-video" label="Light · Video player"      width={390} height={844}><S Screen={ExerciseDetailScreen} t={LT} videoError={false}/></DCArtboard>
+        <DCArtboard id="ex-light-error" label="Light · Video error fallback" width={390} height={844}><S Screen={ExerciseDetailScreen} t={LT} videoError={true}/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="editset" title="10 EditSetSheet"
+        subtitle="Bottom sheet overlay · PR recalculation warning on open · Pre-filled inputs · Save / Delete set · n/a (inline component)">
+        <DCArtboard id="editset-dark"  label="Dark mode"  width={390} height={844}><S Screen={EditSetSheetScreen}  t={DK}/></DCArtboard>
+        <DCArtboard id="editset-light" label="Light mode" width={390} height={844}><S Screen={EditSetSheetScreen}  t={LT}/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="deletedialog" title="11 Delete Workout — Confirmation Dialog"
+        subtitle="Destructive action confirmation · Appears on WorkoutSummaryScreen and WorkoutHistoryScreen · n/a (inline component)">
+        <DCArtboard id="del-dark"  label="Dark mode"  width={390} height={844}><S Screen={DeleteWorkoutDialogScreen} t={DK}/></DCArtboard>
+        <DCArtboard id="del-light" label="Light mode" width={390} height={844}><S Screen={DeleteWorkoutDialogScreen} t={LT}/></DCArtboard>
+      </DCSection>
+    </DesignCanvas>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>

--- a/design/Handoff Bundle.html
+++ b/design/Handoff Bundle.html
@@ -1,0 +1,530 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>PRLifts — Developer Handoff Bundle</title>
+<style>
+:root {
+  --bg:#080A14; --bg2:#10132A; --bg3:#1A1E40; --bg4:#232756;
+  --brand:#1A3FBF; --brandlt:#2D5BE3;
+  --accent:#FFB300; --success:#00DFA2; --error:#FF453A; --warn:#FF9F0A;
+  --text:#fff; --t2:rgba(210,220,255,.65); --t3:rgba(210,220,255,.32);
+  --border:rgba(45,91,227,.18); --borderst:rgba(45,91,227,.32);
+  --font:-apple-system,'SF Pro Text','DM Sans',system-ui,sans-serif;
+  --mono:ui-monospace,'SF Mono',Menlo,monospace;
+}
+*{box-sizing:border-box;margin:0;padding:0;}
+body{background:var(--bg);color:var(--text);font-family:var(--font);font-size:14px;line-height:1.6;display:flex;min-height:100vh;}
+nav{width:220px;background:var(--bg2);border-right:1px solid var(--border);padding:24px 0;position:sticky;top:0;height:100vh;overflow-y:auto;flex-shrink:0;}
+nav h2{font-size:10px;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:var(--t3);padding:0 18px;margin-bottom:6px;margin-top:20px;}
+nav h2:first-of-type{margin-top:0;}
+nav a{display:block;padding:6px 18px;font-size:13px;color:var(--t2);text-decoration:none;border-radius:0;}
+nav a:hover{color:var(--text);background:var(--bg3);}
+nav a.active{color:var(--brandlt);font-weight:600;}
+main{flex:1;padding:40px 48px;max-width:960px;}
+h1{font-size:28px;font-weight:800;letter-spacing:-.5px;color:var(--text);margin-bottom:6px;}
+h2.section{font-size:20px;font-weight:800;color:var(--text);margin:40px 0 16px;padding-top:40px;border-top:1px solid var(--border);}
+h3{font-size:15px;font-weight:700;color:var(--text);margin:24px 0 10px;}
+h4{font-size:13px;font-weight:700;color:var(--t2);margin:16px 0 8px;text-transform:uppercase;letter-spacing:.5px;}
+p{color:var(--t2);margin-bottom:12px;}
+a{color:var(--brandlt);}
+/* Tables */
+table{width:100%;border-collapse:collapse;margin-bottom:20px;font-size:13px;}
+th{text-align:left;padding:8px 12px;background:var(--bg3);color:var(--t3);font-weight:700;font-size:11px;text-transform:uppercase;letter-spacing:.5px;border-bottom:1px solid var(--border);}
+td{padding:9px 12px;border-bottom:1px solid var(--border);color:var(--t2);vertical-align:top;}
+td:first-child{color:var(--text);font-family:var(--mono);font-size:12px;}
+tr:hover td{background:var(--bg2);}
+/* Swatches */
+.sw{display:inline-block;width:14px;height:14px;border-radius:3px;vertical-align:middle;margin-right:6px;flex-shrink:0;border:1px solid rgba(255,255,255,0.08);}
+/* Code blocks */
+pre{background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:18px 20px;overflow-x:auto;margin:10px 0 20px;}
+code{font-family:var(--mono);font-size:12.5px;line-height:1.65;color:rgba(210,220,255,.9);}
+.kw{color:#7C9FFF;} .str{color:#00DFA2;} .cmt{color:rgba(210,220,255,.35);font-style:italic;} .type{color:#FFB300;} .num{color:#FF9F0A;}
+/* Callouts */
+.callout{border-radius:10px;padding:12px 16px;margin:12px 0 20px;border:1px solid;font-size:13px;}
+.callout.gold{background:rgba(255,179,0,.10);border-color:rgba(255,179,0,.28);color:var(--accent);}
+.callout.mint{background:rgba(0,223,162,.10);border-color:rgba(0,223,162,.25);color:var(--success);}
+.callout.blue{background:rgba(26,63,191,.15);border-color:rgba(45,91,227,.30);color:var(--brandlt);}
+.callout.warn{background:rgba(255,159,10,.10);border-color:rgba(255,159,10,.28);color:var(--warn);}
+/* Pills */
+.pill{display:inline-block;padding:2px 9px;border-radius:999px;font-size:11px;font-weight:700;margin-right:4px;}
+.pill.blue{background:rgba(26,63,191,.2);color:var(--brandlt);}
+.pill.gold{background:rgba(255,179,0,.15);color:var(--accent);}
+.pill.mint{background:rgba(0,223,162,.12);color:var(--success);}
+.pill.red{background:rgba(255,69,58,.12);color:var(--error);}
+/* Token row */
+.token-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:8px;margin-bottom:20px;}
+.token-card{background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:10px 12px;}
+.token-name{font-family:var(--mono);font-size:11px;color:var(--t3);margin-bottom:4px;}
+.token-val{font-size:13px;font-weight:700;color:var(--text);}
+.token-sub{font-size:11px;color:var(--t3);margin-top:2px;}
+</style>
+</head>
+<body>
+
+<nav>
+  <h2>Overview</h2>
+  <a href="#intro">Introduction</a>
+  <a href="#howto">How to use</a>
+  <h2>Design Tokens</h2>
+  <a href="#colors">Colors</a>
+  <a href="#typography">Typography</a>
+  <a href="#spacing">Spacing</a>
+  <a href="#radii">Radii &amp; Shadows</a>
+  <a href="#animation">Animation</a>
+  <h2>Components</h2>
+  <a href="#prbutton">PRButton</a>
+  <a href="#prcard">PRCard</a>
+  <a href="#navbar">PRNavBar</a>
+  <a href="#tabbar">PRTabBar</a>
+  <a href="#prbanner">PRNotificationBanner</a>
+  <a href="#sheet">PRBottomSheet</a>
+  <a href="#dialog">PRConfirmationDialog</a>
+  <a href="#video">PRVideoPlayer</a>
+  <a href="#bodydiagram">PRBodyDiagram</a>
+  <a href="#progressdots">PRProgressDots</a>
+  <h2>Screens</h2>
+  <a href="handoff-screens.html" target="_blank">→ Screen Specs (separate doc)</a>
+</nav>
+
+<main>
+
+<!-- ── Introduction ──────────────────────────────────────────── -->
+<h1 id="intro">PRLifts — Developer Handoff Bundle</h1>
+<p style="color:var(--t3);margin-bottom:6px;">Version 2.0 · Approved April 2026 · Obsidian × Velocity Hybrid direction</p>
+<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:24px;">
+  <span class="pill blue">11 screens</span>
+  <span class="pill blue">Dark + light mode</span>
+  <span class="pill gold">Gold = PR moments only</span>
+  <span class="pill mint">Mint = positive deltas</span>
+</div>
+
+<h3 id="howto">How Claude Code should use this bundle</h3>
+<div class="callout blue">
+  This bundle is the authoritative spec for all UI work. Read it before writing any SwiftUI. Never make visual design decisions not covered here — flag and ask instead.
+</div>
+<ol style="color:var(--t2);padding-left:18px;display:flex;flex-direction:column;gap:6px;margin-bottom:24px;">
+  <li>Read this file (tokens + components). Read <a href="handoff-screens.html">handoff-screens.html</a> for per-screen specs.</li>
+  <li>Reference <code>docs/DESIGN_TOKENS.md</code> in the repo for original SwiftUI token definitions — update color values from this bundle (Hybrid direction).</li>
+  <li>Implement tokens as Color/Font/Spacing extensions exactly as specified below.</li>
+  <li>Build the shared components first, then assemble screens from them.</li>
+  <li>Every interactive element requires an <code>.accessibilityLabel</code>. Minimum touch target: 44×44pt.</li>
+</ol>
+
+<!-- ── Colors ────────────────────────────────────────────────── -->
+<h2 class="section" id="colors">Design Tokens — Colors</h2>
+
+<div class="callout warn">
+  <strong>Hybrid direction change from original DESIGN_TOKENS.md:</strong> Dark backgrounds now use a cool blue-indigo scale (not neutral black). Success color is mint #00DFA2 (not green #30D158). Body font is DM Sans (system-ui fallback in code). These values override docs/DESIGN_TOKENS.md.
+</div>
+
+<h4>Asset Catalog Setup — Colors/</h4>
+<p>All colors defined in <code>Assets.xcassets/Colors/</code> with Any (light) and Dark appearances. Use exact values below.</p>
+
+<table>
+  <tr><th>Asset name</th><th>Any (light)</th><th>Dark</th><th>Use</th></tr>
+  <tr><td>PRBrand</td><td><span class="sw" style="background:#1A3FBF"></span>#1A3FBF</td><td><span class="sw" style="background:#1A3FBF"></span>#1A3FBF</td><td>Primary buttons, active states, links</td></tr>
+  <tr><td>PRBrandLight</td><td><span class="sw" style="background:#2D5BE3"></span>#2D5BE3</td><td><span class="sw" style="background:#2D5BE3"></span>#2D5BE3</td><td>Hover states, links, back buttons</td></tr>
+  <tr><td>PRAccent</td><td><span class="sw" style="background:#B5800A"></span>#B5800A</td><td><span class="sw" style="background:#FFB300"></span>#FFB300</td><td>PR achievements ONLY — not general accent</td></tr>
+  <tr><td>PRSuccess</td><td><span class="sw" style="background:#00A37A"></span>#00A37A</td><td><span class="sw" style="background:#00DFA2"></span>#00DFA2</td><td>Positive deltas, sync OK, progress</td></tr>
+  <tr><td>PRWarning</td><td><span class="sw" style="background:#B5680A"></span>#B5680A</td><td><span class="sw" style="background:#FF9F0A"></span>#FF9F0A</td><td>Rate limit, optional fields, PR recalc warning</td></tr>
+  <tr><td>PRError</td><td><span class="sw" style="background:#CC2020"></span>#CC2020</td><td><span class="sw" style="background:#FF453A"></span>#FF453A</td><td>Validation errors, destructive actions</td></tr>
+  <tr><td>PROffline</td><td><span class="sw" style="background:#4A5568"></span>#4A5568</td><td><span class="sw" style="background:#636E8A"></span>#636E8A</td><td>Offline banner, connectivity lost</td></tr>
+  <tr><td>PRBackground</td><td><span class="sw" style="background:#F0F3FF;border-color:rgba(0,0,0,.2)"></span>#F0F3FF</td><td><span class="sw" style="background:#080A14"></span>#080A14</td><td>Primary screen background</td></tr>
+  <tr><td>PRBackgroundSec</td><td><span class="sw" style="background:#FFFFFF;border-color:rgba(0,0,0,.2)"></span>#FFFFFF</td><td><span class="sw" style="background:#10132A"></span>#10132A</td><td>Cards, sheets, grouped content</td></tr>
+  <tr><td>PRBackgroundTer</td><td><span class="sw" style="background:#E2E8FF"></span>#E2E8FF</td><td><span class="sw" style="background:#1A1E40"></span>#1A1E40</td><td>Input fields, segmented controls</td></tr>
+  <tr><td>PRBackgroundQuad</td><td><span class="sw" style="background:#D0D8FF"></span>#D0D8FF</td><td><span class="sw" style="background:#232756"></span>#232756</td><td>Selected segment, control surfaces</td></tr>
+  <tr><td>PRTextPrimary</td><td><span class="sw" style="background:#0F1535"></span>#0F1535</td><td><span class="sw" style="background:#FFFFFF"></span>#FFFFFF</td><td>Headlines, body copy</td></tr>
+  <tr><td>PRTextSecondary</td><td colspan="2" style="font-family:var(--mono);font-size:11px;">Any: rgba(15,21,53,0.60) · Dark: rgba(210,220,255,0.62)</td><td>Subtitles, metadata — cool-tinted in dark</td></tr>
+  <tr><td>PRTextTertiary</td><td colspan="2" style="font-family:var(--mono);font-size:11px;">Any: rgba(15,21,53,0.32) · Dark: rgba(210,220,255,0.28)</td><td>Placeholders, disabled labels</td></tr>
+  <tr><td>PRTextOnBrand</td><td><span class="sw" style="background:#FFFFFF"></span>#FFFFFF</td><td><span class="sw" style="background:#FFFFFF"></span>#FFFFFF</td><td>Text on brand-colored surfaces</td></tr>
+  <tr><td>PRBorder</td><td colspan="2" style="font-family:var(--mono);font-size:11px;">Any: rgba(26,63,191,0.10) · Dark: rgba(45,91,227,0.15)</td><td>Card borders, dividers</td></tr>
+  <tr><td>PRCelebrationStart</td><td><span class="sw" style="background:#FFD60A"></span>#FFD60A</td><td><span class="sw" style="background:#FFD60A"></span>#FFD60A</td><td>Gold gradient start — PR celebrations ONLY</td></tr>
+  <tr><td>PRCelebrationEnd</td><td><span class="sw" style="background:#FF9F0A"></span>#FF9F0A</td><td><span class="sw" style="background:#FF9F0A"></span>#FF9F0A</td><td>Gold gradient end — PR celebrations ONLY</td></tr>
+</table>
+
+<pre><code><span class="cmt">// DesignTokens+Colors.swift — Hybrid direction values</span>
+<span class="kw">extension</span> <span class="type">Color</span> {
+    <span class="kw">static let</span> prBrand           = <span class="type">Color</span>(<span class="str">"PRBrand"</span>)
+    <span class="kw">static let</span> prBrandLight       = <span class="type">Color</span>(<span class="str">"PRBrandLight"</span>)
+    <span class="kw">static let</span> prAccent           = <span class="type">Color</span>(<span class="str">"PRAccent"</span>)          <span class="cmt">// PR moments only</span>
+    <span class="kw">static let</span> prSuccess          = <span class="type">Color</span>(<span class="str">"PRSuccess"</span>)         <span class="cmt">// Mint — positive deltas</span>
+    <span class="kw">static let</span> prWarning          = <span class="type">Color</span>(<span class="str">"PRWarning"</span>)
+    <span class="kw">static let</span> prError            = <span class="type">Color</span>(<span class="str">"PRError"</span>)
+    <span class="kw">static let</span> prOffline          = <span class="type">Color</span>(<span class="str">"PROffline"</span>)
+    <span class="kw">static let</span> prBackground       = <span class="type">Color</span>(<span class="str">"PRBackground"</span>)
+    <span class="kw">static let</span> prBackgroundSec    = <span class="type">Color</span>(<span class="str">"PRBackgroundSec"</span>)
+    <span class="kw">static let</span> prBackgroundTer    = <span class="type">Color</span>(<span class="str">"PRBackgroundTer"</span>)
+    <span class="kw">static let</span> prBackgroundQuad   = <span class="type">Color</span>(<span class="str">"PRBackgroundQuad"</span>)
+    <span class="kw">static let</span> prTextPrimary      = <span class="type">Color</span>(<span class="str">"PRTextPrimary"</span>)
+    <span class="kw">static let</span> prTextSecondary    = <span class="type">Color</span>(<span class="str">"PRTextSecondary"</span>)
+    <span class="kw">static let</span> prTextTertiary     = <span class="type">Color</span>(<span class="str">"PRTextTertiary"</span>)
+    <span class="kw">static let</span> prTextOnBrand      = <span class="type">Color</span>(<span class="str">"PRTextOnBrand"</span>)
+    <span class="kw">static let</span> prBorder           = <span class="type">Color</span>(<span class="str">"PRBorder"</span>)
+    <span class="kw">static let</span> prCelebrationStart = <span class="type">Color</span>(<span class="str">"PRCelebrationStart"</span>)
+    <span class="kw">static let</span> prCelebrationEnd   = <span class="type">Color</span>(<span class="str">"PRCelebrationEnd"</span>)
+}</code></pre>
+
+<!-- ── Typography ─────────────────────────────────────────────── -->
+<h2 class="section" id="typography">Design Tokens — Typography</h2>
+
+<div class="callout blue">
+  On iOS, use <code>Font.system(design: .rounded)</code> for display/headline sizes — this matches SF Pro Rounded. Nunito is the web prototype substitute only. DM Sans maps to system-ui; on iOS this is SF Pro Text.
+</div>
+
+<table>
+  <tr><th>Token</th><th>Size</th><th>Weight</th><th>Design</th><th>Use</th></tr>
+  <tr><td>prDisplayLarge</td><td>48pt</td><td>.black</td><td>.rounded</td><td>Hero PR values, large stats</td></tr>
+  <tr><td>prDisplayMedium</td><td>34pt</td><td>.heavy</td><td>.rounded</td><td>Screen titles, section headlines</td></tr>
+  <tr><td>prHeadlineLarge</td><td>22pt</td><td>.bold</td><td>.rounded</td><td>Card titles, exercise names</td></tr>
+  <tr><td>prHeadlineMedium</td><td>17pt</td><td>.semibold</td><td>.default</td><td>Sub-section titles, set headers</td></tr>
+  <tr><td>prBody</td><td>17pt</td><td>.regular</td><td>.default</td><td>Primary body copy</td></tr>
+  <tr><td>prBodySecondary</td><td>15pt</td><td>.regular</td><td>.default</td><td>Metadata, descriptions</td></tr>
+  <tr><td>prDataLarge</td><td>28pt</td><td>.semibold</td><td>.monospaced</td><td>Primary stat — weight, distance</td></tr>
+  <tr><td>prDataMedium</td><td>20pt</td><td>.medium</td><td>.monospaced</td><td>Set data — weight/reps/RPE</td></tr>
+  <tr><td>prDataSmall</td><td>15pt</td><td>.medium</td><td>.monospaced</td><td>Inline data, history rows</td></tr>
+  <tr><td>prCaption</td><td>13pt</td><td>.regular</td><td>.default</td><td>Labels, tags, badges</td></tr>
+  <tr><td>prCaptionSmall</td><td>11pt</td><td>.regular</td><td>.default</td><td>Timestamps, fine print</td></tr>
+  <tr><td>prButtonPrimary</td><td>17pt</td><td>.bold</td><td>.default</td><td>Primary button label</td></tr>
+  <tr><td>prButtonSecondary</td><td>15pt</td><td>.medium</td><td>.default</td><td>Secondary button label</td></tr>
+</table>
+
+<pre><code><span class="cmt">// DesignTokens+Typography.swift</span>
+<span class="kw">extension</span> <span class="type">Font</span> {
+    <span class="kw">static let</span> prDisplayLarge    = <span class="type">Font</span>.system(size: <span class="num">48</span>, weight: .black,    design: .rounded)
+    <span class="kw">static let</span> prDisplayMedium   = <span class="type">Font</span>.system(size: <span class="num">34</span>, weight: .heavy,    design: .rounded)
+    <span class="kw">static let</span> prHeadlineLarge   = <span class="type">Font</span>.system(size: <span class="num">22</span>, weight: .bold,     design: .rounded)
+    <span class="kw">static let</span> prHeadlineMedium  = <span class="type">Font</span>.system(.headline)          <span class="cmt">// 17 semibold</span>
+    <span class="kw">static let</span> prBody            = <span class="type">Font</span>.system(.body)               <span class="cmt">// 17 regular</span>
+    <span class="kw">static let</span> prBodySecondary   = <span class="type">Font</span>.system(.subheadline)        <span class="cmt">// 15 regular</span>
+    <span class="kw">static let</span> prDataLarge       = <span class="type">Font</span>.system(size: <span class="num">28</span>, weight: .semibold, design: .monospaced)
+    <span class="kw">static let</span> prDataMedium      = <span class="type">Font</span>.system(size: <span class="num">20</span>, weight: .medium,   design: .monospaced)
+    <span class="kw">static let</span> prDataSmall       = <span class="type">Font</span>.system(size: <span class="num">15</span>, weight: .medium,   design: .monospaced)
+    <span class="kw">static let</span> prCaption         = <span class="type">Font</span>.system(.caption)            <span class="cmt">// 13</span>
+    <span class="kw">static let</span> prCaptionSmall    = <span class="type">Font</span>.system(.caption2)           <span class="cmt">// 11</span>
+    <span class="kw">static let</span> prButtonPrimary   = <span class="type">Font</span>.system(.body).weight(.bold)
+    <span class="kw">static let</span> prButtonSecondary = <span class="type">Font</span>.system(.subheadline).weight(.medium)
+}</code></pre>
+
+<!-- ── Spacing ────────────────────────────────────────────────── -->
+<h2 class="section" id="spacing">Design Tokens — Spacing</h2>
+
+<pre><code><span class="cmt">// DesignTokens+Spacing.swift — unchanged from original</span>
+<span class="kw">enum</span> <span class="type">PRSpacing</span> {
+    <span class="kw">static let</span> xxxSmall: <span class="type">CGFloat</span> = <span class="num">4</span>    <span class="cmt">// Icon-to-label</span>
+    <span class="kw">static let</span> xxSmall:  <span class="type">CGFloat</span> = <span class="num">8</span>    <span class="cmt">// Card gap</span>
+    <span class="kw">static let</span> xSmall:   <span class="type">CGFloat</span> = <span class="num">12</span>   <span class="cmt">// Card internals</span>
+    <span class="kw">static let</span> small:    <span class="type">CGFloat</span> = <span class="num">16</span>   <span class="cmt">// ← Standard. Screen horizontal, card padding</span>
+    <span class="kw">static let</span> medium:   <span class="type">CGFloat</span> = <span class="num">20</span>   <span class="cmt">// Between cards</span>
+    <span class="kw">static let</span> large:    <span class="type">CGFloat</span> = <span class="num">24</span>   <span class="cmt">// Section separation</span>
+    <span class="kw">static let</span> xLarge:   <span class="type">CGFloat</span> = <span class="num">32</span>   <span class="cmt">// Screen breathing room</span>
+    <span class="kw">static let</span> xxLarge:  <span class="type">CGFloat</span> = <span class="num">48</span>   <span class="cmt">// Onboarding, hero sections</span>
+    <span class="kw">static let</span> xxxLarge: <span class="type">CGFloat</span> = <span class="num">64</span>   <span class="cmt">// Max whitespace</span>
+    <span class="cmt">// Semantic aliases</span>
+    <span class="kw">static let</span> screenHorizontal:    <span class="type">CGFloat</span> = small      <span class="cmt">// 16</span>
+    <span class="kw">static let</span> cardPadding:          <span class="type">CGFloat</span> = small      <span class="cmt">// 16</span>
+    <span class="kw">static let</span> cardGap:              <span class="type">CGFloat</span> = xxSmall    <span class="cmt">// 8</span>
+    <span class="kw">static let</span> buttonHeight:         <span class="type">CGFloat</span> = <span class="num">50</span>
+    <span class="kw">static let</span> minimumTouchTarget:   <span class="type">CGFloat</span> = <span class="num">44</span>
+}</code></pre>
+
+<!-- ── Radii + Shadows ────────────────────────────────────────── -->
+<h2 class="section" id="radii">Design Tokens — Radii &amp; Shadows</h2>
+
+<pre><code><span class="kw">enum</span> <span class="type">PRRadius</span> {
+    <span class="kw">static let</span> small:  <span class="type">CGFloat</span> = <span class="num">6</span>    <span class="cmt">// Chips, badges, tags</span>
+    <span class="kw">static let</span> medium: <span class="type">CGFloat</span> = <span class="num">10</span>   <span class="cmt">// Input fields, small cards</span>
+    <span class="kw">static let</span> large:  <span class="type">CGFloat</span> = <span class="num">16</span>   <span class="cmt">// Cards, sheets, major UI</span>
+    <span class="kw">static let</span> xLarge: <span class="type">CGFloat</span> = <span class="num">20</span>   <span class="cmt">// Bottom sheets (top corners)</span>
+    <span class="kw">static let</span> pill:   <span class="type">CGFloat</span> = <span class="num">999</span>  <span class="cmt">// Buttons, chips</span>
+}
+
+<span class="kw">struct</span> <span class="type">PRShadow</span> {
+    <span class="kw">let</span> color: <span class="type">Color</span>; <span class="kw">let</span> radius: <span class="type">CGFloat</span>; <span class="kw">let</span> x: <span class="type">CGFloat</span>; <span class="kw">let</span> y: <span class="type">CGFloat</span>
+    <span class="kw">static let</span> low    = <span class="type">PRShadow</span>(color: .black.opacity(<span class="num">0.12</span>), radius: <span class="num">4</span>,  x: <span class="num">0</span>, y: <span class="num">2</span>)
+    <span class="kw">static let</span> medium = <span class="type">PRShadow</span>(color: .black.opacity(<span class="num">0.20</span>), radius: <span class="num">8</span>,  x: <span class="num">0</span>, y: <span class="num">4</span>)
+    <span class="kw">static let</span> high   = <span class="type">PRShadow</span>(color: .black.opacity(<span class="num">0.28</span>), radius: <span class="num">16</span>, x: <span class="num">0</span>, y: <span class="num">8</span>)
+    <span class="kw">static let</span> brand  = <span class="type">PRShadow</span>(color: <span class="type">Color</span>.prBrand.opacity(<span class="num">0.35</span>), radius: <span class="num">16</span>, x: <span class="num">0</span>, y: <span class="num">6</span>)
+    <span class="kw">static let</span> accent = <span class="type">PRShadow</span>(color: <span class="type">Color</span>.prAccent.opacity(<span class="num">0.30</span>), radius: <span class="num">16</span>, x: <span class="num">0</span>, y: <span class="num">6</span>)
+}</code></pre>
+
+<!-- ── Animation ──────────────────────────────────────────────── -->
+<h2 class="section" id="animation">Design Tokens — Animation</h2>
+
+<pre><code><span class="kw">enum</span> <span class="type">PRAnimation</span> {
+    <span class="kw">static let</span> standard    = <span class="type">Animation</span>.easeInOut(duration: <span class="num">0.25</span>)   <span class="cmt">// Screen transitions</span>
+    <span class="kw">static let</span> quick       = <span class="type">Animation</span>.easeOut(duration: <span class="num">0.15</span>)    <span class="cmt">// Button press, toggles</span>
+    <span class="kw">static let</span> celebration = <span class="type">Animation</span>.spring(response: <span class="num">0.4</span>, dampingFraction: <span class="num">0.6</span>) <span class="cmt">// PR banner appear</span>
+    <span class="kw">static let</span> sheet       = <span class="type">Animation</span>.spring(response: <span class="num">0.35</span>, dampingFraction: <span class="num">0.85</span>) <span class="cmt">// Bottom sheet</span>
+}</code></pre>
+
+<!-- ── Components ─────────────────────────────────────────────── -->
+<h2 class="section" id="prbutton">Component — PRButton</h2>
+<p>All interactive buttons in the app use PRButton or follow its spec. Four variants. Never create ad-hoc button styling in views.</p>
+
+<pre><code><span class="kw">enum</span> <span class="type">PRButtonVariant</span> { <span class="kw">case</span> primary, secondary, destructive, ghost }
+
+<span class="kw">struct</span> <span class="type">PRButton</span>: <span class="type">View</span> {
+    <span class="kw">let</span> label: <span class="type">String</span>
+    <span class="kw">var</span> variant: <span class="type">PRButtonVariant</span> = .primary
+    <span class="kw">var</span> icon: <span class="type">String</span>? = <span class="kw">nil</span>           <span class="cmt">// SF Symbol name</span>
+    <span class="kw">var</span> isLoading: <span class="type">Bool</span> = <span class="kw">false</span>
+    <span class="kw">var</span> isDisabled: <span class="type">Bool</span> = <span class="kw">false</span>
+    <span class="kw">let</span> action: () -> <span class="type">Void</span>
+
+    <span class="kw">var</span> body: some <span class="type">View</span> {
+        <span class="type">Button</span>(action: action) {
+            <span class="type">HStack</span>(spacing: <span class="num">8</span>) {
+                <span class="kw">if</span> isLoading { <span class="type">ProgressView</span>().tint(labelColor).scaleEffect(<span class="num">0.85</span>) }
+                <span class="kw">if let</span> icon { <span class="type">Image</span>(systemName: icon) }
+                <span class="type">Text</span>(label).font(buttonFont)
+            }
+            .foregroundColor(labelColor)
+            .frame(maxWidth: .infinity)
+            .frame(height: <span class="type">PRSpacing</span>.buttonHeight)
+            .background(bgColor)
+            .overlay(<span class="type">RoundedRectangle</span>(cornerRadius: <span class="type">PRRadius</span>.pill)
+                .stroke(<span class="type">Color</span>.prBrand, lineWidth: variant == .secondary ? <span class="num">1.5</span> : <span class="num">0</span>))
+            .clipShape(<span class="type">Capsule</span>())
+            .shadow(color: shadowColor, radius: shadowRadius, x: <span class="num">0</span>, y: <span class="num">6</span>)
+        }
+        .disabled(isDisabled || isLoading)
+        .accessibilityLabel(label)
+    }
+    <span class="kw">private var</span> bgColor: <span class="type">Color</span> {
+        <span class="kw">switch</span> variant {
+        <span class="kw">case</span> .primary:     <span class="kw">return</span> isDisabled ? .prBackgroundTer : .prBrand
+        <span class="kw">case</span> .secondary:   <span class="kw">return</span> .clear
+        <span class="kw">case</span> .destructive: <span class="kw">return</span> .prError
+        <span class="kw">case</span> .ghost:       <span class="kw">return</span> .clear
+        }
+    }
+    <span class="kw">private var</span> labelColor: <span class="type">Color</span> {
+        <span class="kw">switch</span> variant {
+        <span class="kw">case</span> .primary:     <span class="kw">return</span> isDisabled ? .prTextTertiary : .prTextOnBrand
+        <span class="kw">case</span> .secondary:   <span class="kw">return</span> .prBrandLight
+        <span class="kw">case</span> .destructive: <span class="kw">return</span> .white
+        <span class="kw">case</span> .ghost:       <span class="kw">return</span> .prTextSecondary
+        }
+    }
+    <span class="kw">private var</span> buttonFont: <span class="type">Font</span> {
+        variant == .secondary ? .prButtonSecondary : .prButtonPrimary
+    }
+    <span class="kw">private var</span> shadowColor: <span class="type">Color</span>  { variant == .primary && !isDisabled ? <span class="type">Color</span>.prBrand.opacity(<span class="num">0.35</span>) : .clear }
+    <span class="kw">private var</span> shadowRadius: <span class="type">CGFloat</span> { variant == .primary ? <span class="num">16</span> : <span class="num">0</span> }
+}</code></pre>
+
+<h2 class="section" id="prcard">Component — PRCard</h2>
+<pre><code><span class="kw">struct</span> <span class="type">PRCard</span>&lt;Content: <span class="type">View</span>&gt;: <span class="type">View</span> {
+    <span class="kw">var</span> padding: <span class="type">CGFloat</span> = <span class="type">PRSpacing</span>.cardPadding
+    <span class="kw">var</span> radius: <span class="type">CGFloat</span>  = <span class="type">PRRadius</span>.large
+    @<span class="type">ViewBuilder</span> <span class="kw">let</span> content: () -> Content
+
+    <span class="kw">var</span> body: some <span class="type">View</span> {
+        content()
+            .padding(padding)
+            .background(<span class="type">Color</span>.prBackgroundSec)
+            .clipShape(<span class="type">RoundedRectangle</span>(cornerRadius: radius))
+            .overlay(<span class="type">RoundedRectangle</span>(cornerRadius: radius)
+                .stroke(<span class="type">Color</span>.prBorder, lineWidth: <span class="num">1</span>))
+            .shadow(color: <span class="type">PRShadow</span>.low.color, radius: <span class="type">PRShadow</span>.low.radius,
+                    x: <span class="type">PRShadow</span>.low.x, y: <span class="type">PRShadow</span>.low.y)
+    }
+}</code></pre>
+
+<h2 class="section" id="navbar">Component — PRNavBar</h2>
+<pre><code><span class="kw">struct</span> <span class="type">PRNavBar</span>: <span class="type">View</span> {
+    <span class="kw">var</span> title: <span class="type">String</span>                    = <span class="str">""</span>
+    <span class="kw">var</span> leadingAction: (() -> <span class="type">Void</span>)?      = <span class="kw">nil</span>
+    <span class="kw">var</span> trailingContent: <span class="type">AnyView</span>?        = <span class="kw">nil</span>
+    <span class="kw">var</span> showDivider: <span class="type">Bool</span>                = <span class="kw">true</span>
+
+    <span class="kw">var</span> body: some <span class="type">View</span> {
+        <span class="type">HStack</span>(spacing: <span class="num">0</span>) {
+            <span class="cmt">// Leading — 36pt wide</span>
+            <span class="type">Group</span> {
+                <span class="kw">if let</span> action = leadingAction {
+                    <span class="type">Button</span>(action: action) {
+                        <span class="type">Image</span>(systemName: <span class="str">"chevron.left"</span>)
+                            .font(.system(size: <span class="num">17</span>, weight: .semibold))
+                            .foregroundColor(.prBrandLight)
+                    }
+                }
+            }.frame(width: <span class="num">36</span>, alignment: .leading)
+
+            <span class="type">Spacer</span>()
+            <span class="type">Text</span>(title).font(.prHeadlineMedium).foregroundColor(.prTextPrimary)
+            <span class="type">Spacer</span>()
+
+            <span class="cmt">// Trailing — 36pt wide</span>
+            <span class="type">Group</span> { trailingContent }.frame(width: <span class="num">36</span>, alignment: .trailing)
+        }
+        .padding(.horizontal, <span class="type">PRSpacing</span>.screenHorizontal)
+        .frame(height: <span class="num">50</span>)
+        .background(<span class="type">Color</span>.prBackground)
+        .<span class="kw">if</span>(showDivider) { $<span class="num">0</span>.overlay(<span class="type">Color</span>.prBorder.frame(height: <span class="num">1</span>), alignment: .bottom) }
+    }
+}</code></pre>
+
+<h2 class="section" id="tabbar">Component — PRTabBar</h2>
+<pre><code><span class="cmt">// Use SwiftUI TabView — customise appearance via UIKit proxy</span>
+<span class="kw">init</span>() {
+    <span class="type">UITabBar</span>.appearance().backgroundColor       = <span class="type">UIColor</span>(<span class="type">Color</span>.prBackgroundSec)
+    <span class="type">UITabBar</span>.appearance().unselectedItemTintColor = <span class="type">UIColor</span>(<span class="type">Color</span>.prTextTertiary)
+}
+
+<span class="type">TabView</span>(selection: $tab) {
+    <span class="type">HomeView</span>().tabItem { <span class="type">Label</span>(<span class="str">"Home"</span>, systemImage: <span class="str">"house.fill"</span>) }.tag(<span class="type">Tab</span>.home)
+    <span class="type">HistoryView</span>().tabItem { <span class="type">Label</span>(<span class="str">"History"</span>, systemImage: <span class="str">"clock.arrow.circlepath"</span>) }.tag(<span class="type">Tab</span>.history)
+    <span class="type">ExerciseLibraryView</span>().tabItem { <span class="type">Label</span>(<span class="str">"Exercises"</span>, systemImage: <span class="str">"list.bullet"</span>) }.tag(<span class="type">Tab</span>.exercises)
+    <span class="type">ProfileView</span>().tabItem { <span class="type">Label</span>(<span class="str">"Profile"</span>, systemImage: <span class="str">"person.circle"</span>) }.tag(<span class="type">Tab</span>.profile)
+}.tint(<span class="type">Color</span>.prBrand)</code></pre>
+
+<h2 class="section" id="prbanner">Component — PRNotificationBanner</h2>
+<div class="callout gold">Appears inline on ActiveWorkoutScreen when a PR is detected. Gold gradient treatment. Springs in with PRAnimation.celebration. Dismissible via swipe or tap ×.</div>
+<pre><code><span class="kw">struct</span> <span class="type">PRNotificationBanner</span>: <span class="type">View</span> {
+    <span class="kw">let</span> exerciseName: <span class="type">String</span>
+    <span class="kw">let</span> newValue: <span class="type">String</span>; <span class="kw">let</span> unit: <span class="type">String</span>
+    <span class="kw">let</span> previousValue: <span class="type">String</span>; <span class="kw">let</span> delta: <span class="type">String</span>
+    <span class="kw">var</span> onTap: (() -> <span class="type">Void</span>)? = <span class="kw">nil</span>
+    <span class="kw">var</span> onDismiss: (() -> <span class="type">Void</span>)? = <span class="kw">nil</span>
+    @<span class="type">State</span> <span class="kw">private var</span> offset: <span class="type">CGFloat</span> = -<span class="num">80</span>
+
+    <span class="kw">var</span> body: some <span class="type">View</span> {
+        <span class="type">HStack</span>(spacing: <span class="num">12</span>) {
+            <span class="cmt">// Trophy circle</span>
+            <span class="type">Circle</span>()
+                .fill(<span class="type">LinearGradient</span>(colors: [.prCelebrationStart, .prCelebrationEnd],
+                    startPoint: .topLeading, endPoint: .bottomTrailing))
+                .frame(width: <span class="num">40</span>, height: <span class="num">40</span>)
+                .overlay(<span class="type">Text</span>(<span class="str">"🏆"</span>).font(.system(size: <span class="num">18</span>)))
+                .shadow(color: .prAccent.opacity(<span class="num">0.35</span>), radius: <span class="num">8</span>, x: <span class="num">0</span>, y: <span class="num">4</span>)
+            <span class="type">VStack</span>(alignment: .leading, spacing: <span class="num">2</span>) {
+                <span class="type">Text</span>(<span class="str">"Personal Record"</span>)
+                    .font(.prCaptionSmall).fontWeight(.bold).textCase(.uppercase)
+                    .tracking(<span class="num">0.5</span>).foregroundColor(.prAccent)
+                <span class="type">Text</span>(<span class="str">"\(exerciseName) · \(newValue) \(unit)"</span>)
+                    .font(.prHeadlineMedium).foregroundColor(.prTextPrimary)
+                <span class="type">Text</span>(<span class="str">"Previous: \(previousValue) · "</span> + delta)
+                    .font(.prCaption).foregroundColor(.prTextSecondary)
+                    + <span class="type">Text</span>(delta).font(.prCaption).foregroundColor(.prSuccess)
+            }
+            <span class="type">Spacer</span>()
+            <span class="kw">if let</span> dismiss = onDismiss {
+                <span class="type">Button</span>(action: dismiss) {
+                    <span class="type">Image</span>(systemName: <span class="str">"xmark"</span>)
+                        .font(.system(size: <span class="num">12</span>, weight: .semibold))
+                        .foregroundColor(.prTextTertiary)
+                }.accessibilityLabel(<span class="str">"Dismiss"</span>)
+            }
+        }
+        .padding(<span class="num">14</span>)
+        .background(<span class="type">LinearGradient</span>(
+            colors: [<span class="type">Color</span>.prCelebrationStart.opacity(<span class="num">0.12</span>), <span class="type">Color</span>.prCelebrationEnd.opacity(<span class="num">0.06</span>)],
+            startPoint: .topLeading, endPoint: .bottomTrailing))
+        .overlay(<span class="type">RoundedRectangle</span>(cornerRadius: <span class="type">PRRadius</span>.large)
+            .stroke(<span class="type">Color</span>.prAccent.opacity(<span class="num">0.30</span>), lineWidth: <span class="num">1</span>))
+        .clipShape(<span class="type">RoundedRectangle</span>(cornerRadius: <span class="type">PRRadius</span>.large))
+        .offset(y: offset)
+        .onAppear { <span class="kw">withAnimation</span>(<span class="type">PRAnimation</span>.celebration) { offset = <span class="num">0</span> } }
+        .onTapGesture { onTap?() }
+    }
+}</code></pre>
+
+<h2 class="section" id="sheet">Component — PRBottomSheet</h2>
+<pre><code><span class="cmt">// Use native .sheet() modifier with custom detents for most cases.
+// For EditSetSheet use a custom presentation with fixed height detent.</span>
+.<span class="kw">sheet</span>(isPresented: $showEditSet) {
+    <span class="type">EditSetSheetView</span>(set: selectedSet)
+        .presentationDetents([.fraction(<span class="num">0.62</span>)])
+        .presentationDragIndicator(.visible)
+        .presentationBackground(<span class="type">Color</span>.prBackgroundSec)
+}
+<span class="cmt">// PRWarningBanner inside the sheet — show IMMEDIATELY on appear, not after interaction:</span>
+<span class="type">PRWarningBanner</span>(message: <span class="str">"Editing this set will recalculate your personal record"</span>)
+    .padding(.horizontal, <span class="num">16</span>)
+    .onAppear() <span class="cmt">// No animation delay — fires on sheet appear</span></code></pre>
+
+<h2 class="section" id="dialog">Component — PRConfirmationDialog</h2>
+<pre><code><span class="cmt">// Use SwiftUI .confirmationDialog() for Delete workout
+// Do NOT use .alert() — confirmationDialog gives the correct sheet-style presentation</span>
+.<span class="kw">confirmationDialog</span>(
+    <span class="str">"Delete workout?"</span>,
+    isPresented: $showDeleteConfirm,
+    titleVisibility: .visible
+) {
+    <span class="type">Button</span>(<span class="str">"Delete workout"</span>, role: .destructive) { deleteWorkout() }
+    <span class="type">Button</span>(<span class="str">"Cancel"</span>, role: .cancel) {}
+} message: {
+    <span class="type">Text</span>(<span class="str">"This will permanently delete this workout and all its sets. Your personal records may be updated."</span>)
+}
+<span class="cmt">// For the centered dialog design shown in the spec, use a custom modal overlay instead:
+// ZStack { background.blur(radius: 2); PRDeleteDialogCard(onDelete:, onCancel:) }</span></code></pre>
+
+<h2 class="section" id="video">Component — PRVideoPlayerCard</h2>
+<pre><code><span class="cmt">// ExerciseDetailScreen: load video from ExerciseDB demo_url
+// Use VideoPlayer from AVKit. If URL is nil or fails to load → show PRBodyDiagram.</span>
+<span class="kw">import</span> AVKit
+
+<span class="kw">struct</span> <span class="type">PRVideoPlayerCard</span>: <span class="type">View</span> {
+    <span class="kw">let</span> demoURL: <span class="type">URL</span>?
+    <span class="kw">let</span> exerciseName: <span class="type">String</span>
+    <span class="kw">let</span> primaryMuscle: <span class="type">String</span>
+    @<span class="type">State</span> <span class="kw">private var</span> loadFailed = <span class="kw">false</span>
+
+    <span class="kw">var</span> body: some <span class="type">View</span> {
+        <span class="type">Group</span> {
+            <span class="kw">if let</span> url = demoURL, !loadFailed {
+                <span class="type">VideoPlayer</span>(player: <span class="type">AVPlayer</span>(url: url))
+                    .onAppear { <span class="cmt">/* set up player */</span> }
+                    .overlay(<span class="cmt">/* bottom gradient + title */</span>)
+            } <span class="kw">else</span> {
+                <span class="type">PRBodyDiagram</span>(primaryMuscles: [primaryMuscle])
+            }
+        }
+        .frame(height: <span class="num">200</span>)
+        .clipShape(<span class="type">RoundedRectangle</span>(cornerRadius: <span class="type">PRRadius</span>.large))
+        .overlay(<span class="type">RoundedRectangle</span>(cornerRadius: <span class="type">PRRadius</span>.large)
+            .stroke(<span class="type">Color</span>.prBorder, lineWidth: <span class="num">1</span>))
+    }
+}
+<span class="cmt">// loadFailed = true when: demoURL == nil, OR AVPlayer fires .failed status</span></code></pre>
+
+<h2 class="section" id="bodydiagram">Component — PRBodyDiagram</h2>
+<pre><code><span class="cmt">// SVG-style body diagram using SwiftUI shapes/paths.
+// Primary muscle: Color.prBrand opacity 0.82
+// Secondary muscles: Color.prBrandLight opacity 0.50
+// All other areas: Color.prTextTertiary opacity 0.15–0.22
+// Render as Canvas or Path-based SwiftUI shapes.
+// Muscle group identifiers match ExerciseDB API muscle field values:</span>
+<span class="kw">enum</span> <span class="type">MuscleGroup</span>: <span class="type">String</span> {
+    <span class="kw">case</span> chest, back, shoulders, biceps, triceps, quadriceps, hamstrings, calves, glutes, abs
+}
+<span class="cmt">// See design spec: screens/screens-extra.jsx BodyDiagram() for SVG path reference</span></code></pre>
+
+<h2 class="section" id="progressdots">Component — PRProgressDots</h2>
+<pre><code><span class="cmt">// Onboarding step indicator. Active step: wide pill (20pt), others: circle (6pt).</span>
+<span class="kw">struct</span> <span class="type">PRProgressDots</span>: <span class="type">View</span> {
+    <span class="kw">let</span> total: <span class="type">Int</span>
+    <span class="kw">let</span> current: <span class="type">Int</span>  <span class="cmt">// 1-indexed</span>
+
+    <span class="kw">var</span> body: some <span class="type">View</span> {
+        <span class="type">HStack</span>(spacing: <span class="num">6</span>) {
+            <span class="type">ForEach</span>(<span class="num">1</span>...<span class="kw">total</span>, id: \.self) { step <span class="kw">in</span>
+                <span class="type">RoundedRectangle</span>(cornerRadius: <span class="num">999</span>)
+                    .fill(step == current ? <span class="type">Color</span>.prBrand : <span class="type">Color</span>.prBackgroundTer)
+                    .frame(width: step == current ? <span class="num">20</span> : <span class="num">6</span>, height: <span class="num">6</span>)
+                    .animation(<span class="type">PRAnimation</span>.standard, value: current)
+            }
+        }
+    }
+}
+<span class="cmt">// Usage: PRProgressDots(total: 4, current: viewModel.step)</span></code></pre>
+
+<div style="margin-top:48px;padding-top:24px;border-top:1px solid var(--border);">
+  <p style="color:var(--t3);font-size:12px;">PRLifts Design System v2.0 · Obsidian × Velocity Hybrid · Approved April 2026</p>
+  <p style="margin-top:6px;"><a href="handoff-screens.html">→ Continue to Screen Specs</a></p>
+</div>
+</main>
+</body>
+</html>

--- a/design/colors_and_type.css
+++ b/design/colors_and_type.css
@@ -1,0 +1,210 @@
+/**
+ * PRLifts Design Tokens — CSS
+ * Version: 2.0 | April 2026
+ * Direction: Obsidian × Velocity Hybrid
+ *
+ * Brand:   Deep blue #1A3FBF + Gold #FFB300
+ * Success: Mint #00DFA2 (dark) / #00A37A (light)
+ * Cards:   Cool blue-indigo dark backgrounds
+ * Body:    DM Sans · Display: Nunito · Mono: SF Mono / ui-monospace
+ *
+ * Usage:
+ *   Default = dark mode.
+ *   Add [data-theme="light"] to <html> for light mode.
+ *   Both modes use the same CSS variable names — swap the root.
+ *
+ * Font imports (add to <head>):
+ *   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+ */
+
+/* ─── Dark Mode (default) ────────────────────────────────────────── */
+:root {
+
+  /* Brand */
+  --pr-brand:            #1A3FBF;
+  --pr-brand-lt:         #2D5BE3;
+  --pr-brand-dk:         #0F2A8A;
+  --pr-brand-glow:       rgba(26,63,191,0.35);
+  --pr-brand-subtle:     rgba(26,63,191,0.15);
+
+  /* Accent — Gold (PRs, achievements) */
+  --pr-accent:           #FFB300;
+  --pr-accent-lt:        #FFD040;
+  --pr-accent-dk:        #E09A00;
+  --pr-accent-glow:      rgba(255,179,0,0.30);
+  --pr-accent-subtle:    rgba(255,179,0,0.12);
+
+  /* Celebration gradient — PR moments only */
+  --pr-cel-start:        #FFD60A;
+  --pr-cel-end:          #FF9F0A;
+  --pr-cel-glow:         rgba(255,214,10,0.25);
+
+  /* Backgrounds — cool blue-indigo dark scale */
+  --pr-bg:               #080A14;
+  --pr-bg-sec:           #10132A;
+  --pr-bg-ter:           #1A1E40;
+  --pr-bg-quad:          #232756;
+
+  /* Text — cool-tinted white */
+  --pr-text-pri:         #FFFFFF;
+  --pr-text-sec:         rgba(210,220,255,0.62);
+  --pr-text-ter:         rgba(210,220,255,0.28);
+  --pr-text-on-brand:    #FFFFFF;
+  --pr-text-on-accent:   #0A0A0F;
+
+  /* Semantic */
+  --pr-success:          #00DFA2;   /* Mint — positive deltas, sync OK */
+  --pr-success-bg:       rgba(0,223,162,0.12);
+  --pr-warning:          #FF9F0A;
+  --pr-warning-bg:       rgba(255,159,10,0.12);
+  --pr-error:            #FF453A;
+  --pr-error-bg:         rgba(255,69,58,0.12);
+  --pr-offline:          #636E8A;
+  --pr-offline-bg:       rgba(99,110,138,0.12);
+
+  /* Borders */
+  --pr-border:           rgba(45,91,227,0.15);
+  --pr-border-st:        rgba(45,91,227,0.30);
+
+  /* Spacing */
+  --pr-space-xxxs:       4px;
+  --pr-space-xxs:        8px;
+  --pr-space-xs:         12px;
+  --pr-space-sm:         16px;
+  --pr-space-md:         20px;
+  --pr-space-lg:         24px;
+  --pr-space-xl:         32px;
+  --pr-space-xxl:        48px;
+  --pr-space-xxxl:       64px;
+  --pr-screen-h:         var(--pr-space-sm);
+  --pr-card-pad:         var(--pr-space-sm);
+  --pr-card-gap:         var(--pr-space-xxs);
+  --pr-btn-h:            50px;
+  --pr-touch-min:        44px;
+
+  /* Radii */
+  --pr-radius-sm:        6px;
+  --pr-radius-md:        10px;
+  --pr-radius-lg:        16px;
+  --pr-radius-xl:        20px;
+  --pr-radius-pill:      999px;
+
+  /* Shadows */
+  --pr-shadow-low:       0 2px 4px rgba(0,0,0,0.16);
+  --pr-shadow-md:        0 4px 12px rgba(0,0,0,0.24);
+  --pr-shadow-high:      0 8px 24px rgba(0,0,0,0.32);
+  --pr-shadow-brand:     0 6px 20px rgba(26,63,191,0.35);
+  --pr-shadow-accent:    0 6px 20px rgba(255,179,0,0.30);
+
+  /* Animations */
+  --pr-ease-std:         cubic-bezier(0.4,0,0.2,1);
+  --pr-ease-out:         cubic-bezier(0,0,0.2,1);
+  --pr-ease-spring:      cubic-bezier(0.34,1.56,0.64,1);
+  --pr-dur-std:          0.25s;
+  --pr-dur-quick:        0.15s;
+  --pr-dur-spring:       0.4s;
+
+  /* Typography */
+  --pr-font-display:     'Nunito', -apple-system, 'SF Pro Rounded', system-ui, sans-serif;
+  --pr-font-body:        'DM Sans', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --pr-font-mono:        'SF Mono', ui-monospace, Menlo, monospace;
+}
+
+/* ─── Light Mode ─────────────────────────────────────────────────── */
+[data-theme="light"] {
+
+  /* Brand stays identical */
+  --pr-brand:            #1A3FBF;
+  --pr-brand-lt:         #2D5BE3;
+  --pr-brand-dk:         #0F2A8A;
+  --pr-brand-glow:       rgba(26,63,191,0.20);
+  --pr-brand-subtle:     rgba(26,63,191,0.10);
+
+  /* Accent — richer gold for light surfaces */
+  --pr-accent:           #B5800A;
+  --pr-accent-lt:        #D4960D;
+  --pr-accent-dk:        #8A5F07;
+  --pr-accent-glow:      rgba(181,128,10,0.20);
+  --pr-accent-subtle:    rgba(181,128,10,0.10);
+
+  /* Celebration unchanged */
+  --pr-cel-start:        #FFD60A;
+  --pr-cel-end:          #FF9F0A;
+  --pr-cel-glow:         rgba(255,214,10,0.20);
+
+  /* Backgrounds — cool lavender-blue light scale */
+  --pr-bg:               #F0F3FF;
+  --pr-bg-sec:           #FFFFFF;
+  --pr-bg-ter:           #E2E8FF;
+  --pr-bg-quad:          #D0D8FF;
+
+  /* Text — deep blue-black */
+  --pr-text-pri:         #0F1535;
+  --pr-text-sec:         rgba(15,21,53,0.60);
+  --pr-text-ter:         rgba(15,21,53,0.32);
+  --pr-text-on-brand:    #FFFFFF;
+  --pr-text-on-accent:   #FFFFFF;
+
+  /* Semantic — slightly richer for light backgrounds */
+  --pr-success:          #00A37A;
+  --pr-success-bg:       rgba(0,163,122,0.12);
+  --pr-warning:          #B5680A;
+  --pr-warning-bg:       rgba(181,104,10,0.10);
+  --pr-error:            #CC2020;
+  --pr-error-bg:         rgba(204,32,32,0.10);
+  --pr-offline:          #4A5568;
+  --pr-offline-bg:       rgba(74,85,104,0.10);
+
+  /* Borders */
+  --pr-border:           rgba(26,63,191,0.10);
+  --pr-border-st:        rgba(26,63,191,0.22);
+
+  /* Shadows — lighter for light mode */
+  --pr-shadow-low:       0 2px 6px rgba(15,21,53,0.08);
+  --pr-shadow-md:        0 4px 12px rgba(15,21,53,0.10);
+  --pr-shadow-high:      0 8px 24px rgba(15,21,53,0.12);
+  --pr-shadow-brand:     0 6px 20px rgba(26,63,191,0.25);
+  --pr-shadow-accent:    0 6px 20px rgba(181,128,10,0.20);
+}
+
+/* ─── Typography Class Helpers ───────────────────────────────────── */
+.pr-display-lg  { font-family:var(--pr-font-display); font-size:48px; font-weight:900; line-height:1.05; letter-spacing:-0.5px; }
+.pr-display-md  { font-family:var(--pr-font-display); font-size:34px; font-weight:800; line-height:1.1;  letter-spacing:-0.3px; }
+.pr-headline-lg { font-family:var(--pr-font-display); font-size:22px; font-weight:700; line-height:1.2;  }
+.pr-headline-md { font-family:var(--pr-font-body);    font-size:17px; font-weight:600; line-height:1.3;  }
+.pr-body        { font-family:var(--pr-font-body);    font-size:17px; font-weight:400; line-height:1.5;  }
+.pr-body-sec    { font-family:var(--pr-font-body);    font-size:15px; font-weight:400; line-height:1.45; }
+.pr-data-lg     { font-family:var(--pr-font-mono);    font-size:28px; font-weight:600; line-height:1.1;  font-variant-numeric:tabular-nums; }
+.pr-data-md     { font-family:var(--pr-font-mono);    font-size:20px; font-weight:500; line-height:1.2;  font-variant-numeric:tabular-nums; }
+.pr-data-sm     { font-family:var(--pr-font-mono);    font-size:15px; font-weight:500; line-height:1.3;  font-variant-numeric:tabular-nums; }
+.pr-caption     { font-family:var(--pr-font-body);    font-size:13px; font-weight:400; line-height:1.4;  }
+.pr-caption-sm  { font-family:var(--pr-font-body);    font-size:11px; font-weight:400; line-height:1.4;  }
+.pr-btn-pri     { font-family:var(--pr-font-body);    font-size:17px; font-weight:700; }
+.pr-btn-sec     { font-family:var(--pr-font-body);    font-size:15px; font-weight:500; }
+
+/* ─── Component Helpers ──────────────────────────────────────────── */
+.pr-card {
+  background:     var(--pr-bg-sec);
+  border-radius:  var(--pr-radius-lg);
+  box-shadow:     var(--pr-shadow-low);
+  padding:        var(--pr-card-pad);
+  border:         1px solid var(--pr-border);
+}
+.pr-btn-base {
+  display:         inline-flex;
+  align-items:     center;
+  justify-content: center;
+  min-height:      var(--pr-btn-h);
+  border-radius:   var(--pr-radius-pill);
+  border:          none;
+  cursor:          pointer;
+  font-family:     var(--pr-font-body);
+  font-size:       17px;
+  font-weight:     700;
+  transition:      opacity var(--pr-dur-quick) var(--pr-ease-out), transform var(--pr-dur-quick) var(--pr-ease-out);
+}
+.pr-btn-base:active { opacity: 0.82; transform: scale(0.98); }
+.pr-btn-primary     { background: var(--pr-brand); color: var(--pr-text-on-brand); box-shadow: var(--pr-shadow-brand); }
+.pr-btn-secondary   { background: transparent; color: var(--pr-brand); border: 1.5px solid var(--pr-brand); }
+.pr-btn-destructive { background: var(--pr-error); color: #fff; }
+.pr-btn-ghost       { background: transparent; color: var(--pr-text-pri); }

--- a/design/handoff-screens.html
+++ b/design/handoff-screens.html
@@ -1,0 +1,467 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>PRLifts — Screen Specs</title>
+<style>
+:root {
+  --bg:#080A14;--bg2:#10132A;--bg3:#1A1E40;--bg4:#232756;
+  --brand:#1A3FBF;--brandlt:#2D5BE3;
+  --accent:#FFB300;--success:#00DFA2;--error:#FF453A;--warn:#FF9F0A;
+  --text:#fff;--t2:rgba(210,220,255,.65);--t3:rgba(210,220,255,.32);
+  --border:rgba(45,91,227,.18);
+  --font:-apple-system,'SF Pro Text','DM Sans',system-ui,sans-serif;
+  --mono:ui-monospace,'SF Mono',Menlo,monospace;
+}
+*{box-sizing:border-box;margin:0;padding:0;}
+body{background:var(--bg);color:var(--text);font-family:var(--font);font-size:14px;line-height:1.6;display:flex;min-height:100vh;}
+nav{width:220px;background:var(--bg2);border-right:1px solid var(--border);padding:20px 0;position:sticky;top:0;height:100vh;overflow-y:auto;flex-shrink:0;}
+nav .back{display:block;padding:8px 18px 14px;font-size:13px;color:var(--brandlt);text-decoration:none;border-bottom:1px solid var(--border);margin-bottom:8px;}
+nav h2{font-size:10px;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:var(--t3);padding:0 18px;margin-bottom:4px;margin-top:14px;}
+nav a{display:block;padding:5px 18px;font-size:13px;color:var(--t2);text-decoration:none;}
+nav a:hover{color:var(--text);background:var(--bg3);}
+main{flex:1;padding:36px 48px;max-width:960px;}
+h1{font-size:26px;font-weight:800;letter-spacing:-.5px;margin-bottom:6px;}
+.screen{margin-bottom:0;padding:36px 0;border-top:1px solid var(--border);}
+.screen:first-of-type{border-top:none;padding-top:0;}
+.screen-header{display:flex;align-items:flex-start;gap:16px;margin-bottom:18px;}
+.screen-num{font-size:11px;font-weight:700;color:var(--t3);background:var(--bg3);border-radius:6px;padding:3px 8px;white-space:nowrap;margin-top:3px;}
+.screen-title{font-size:20px;font-weight:800;color:var(--text);margin-bottom:3px;}
+.screen-route{font-family:var(--mono);font-size:12px;color:var(--t3);}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:14px;}
+.grid-3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;margin-bottom:14px;}
+.box{background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:12px 14px;}
+.box-label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.6px;color:var(--t3);margin-bottom:6px;}
+.box-content{font-size:13px;color:var(--t2);line-height:1.5;}
+.box-content li{margin-left:14px;margin-bottom:3px;}
+.box-content code{font-family:var(--mono);font-size:11px;color:var(--brandlt);}
+.box-content strong{color:var(--text);font-weight:600;}
+pre{background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:14px 16px;overflow-x:auto;margin:8px 0 14px;font-family:var(--mono);font-size:12px;line-height:1.6;color:rgba(210,220,255,.88);}
+.kw{color:#7C9FFF;}.str{color:#00DFA2;}.cmt{color:rgba(210,220,255,.35);font-style:italic;}.type{color:#FFB300;}.num{color:#FF9F0A;}
+.tag{display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:700;margin-right:4px;margin-bottom:4px;}
+.tag.blue{background:rgba(26,63,191,.2);color:var(--brandlt);}
+.tag.gold{background:rgba(255,179,0,.15);color:var(--accent);}
+.tag.mint{background:rgba(0,223,162,.12);color:var(--success);}
+.tag.red{background:rgba(255,69,58,.12);color:var(--error);}
+.tag.warn{background:rgba(255,159,10,.12);color:var(--warn);}
+.tag.gray{background:var(--bg3);color:var(--t2);}
+.callout{border-radius:10px;padding:11px 14px;margin:10px 0 14px;border:1px solid;font-size:13px;}
+.callout.gold{background:rgba(255,179,0,.10);border-color:rgba(255,179,0,.28);color:var(--accent);}
+.callout.mint{background:rgba(0,223,162,.10);border-color:rgba(0,223,162,.25);color:var(--success);}
+.callout.blue{background:rgba(26,63,191,.15);border-color:rgba(45,91,227,.30);color:var(--brandlt);}
+.callout.warn{background:rgba(255,159,10,.10);border-color:rgba(255,159,10,.28);color:var(--warn);}
+.callout.red{background:rgba(255,69,58,.10);border-color:rgba(255,69,58,.28);color:var(--error);}
+table{width:100%;border-collapse:collapse;margin:8px 0 14px;font-size:13px;}
+th{text-align:left;padding:7px 10px;background:var(--bg3);color:var(--t3);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;border-bottom:1px solid var(--border);}
+td{padding:8px 10px;border-bottom:1px solid var(--border);color:var(--t2);vertical-align:top;}
+td code{font-family:var(--mono);font-size:11px;color:var(--brandlt);}
+td:first-child{color:var(--text);font-weight:600;}
+</style>
+</head>
+<body>
+<nav>
+  <a href="Handoff Bundle.html" class="back">← Tokens &amp; Components</a>
+  <h2>Onboarding</h2>
+  <a href="#s01">01 WelcomeScreen</a>
+  <a href="#s02">02 SignInScreen</a>
+  <a href="#s03">03 DisplayNameScreen</a>
+  <a href="#s04">04 UnitPreferenceScreen</a>
+  <h2>Core App</h2>
+  <a href="#s05">05 HomeScreen</a>
+  <a href="#s06">06 ActiveWorkoutScreen</a>
+  <a href="#s07">07 WorkoutSummaryScreen</a>
+  <a href="#s08">08 PRDetailScreen</a>
+  <h2>Additional</h2>
+  <a href="#s09">09 ExerciseDetailScreen</a>
+  <a href="#s10">10 EditSetSheet</a>
+  <a href="#s11">11 DeleteWorkoutDialog</a>
+</nav>
+<main>
+<h1 style="margin-bottom:4px;">PRLifts — Screen Specs</h1>
+<p style="color:var(--t3);font-size:13px;margin-bottom:32px;">11 screens · v2.0 · Read <a href="Handoff Bundle.html">Handoff Bundle.html</a> first for token and component definitions.</p>
+
+<!-- ── 01 WelcomeScreen ──────────────────────────────────────────── -->
+<div class="screen" id="s01">
+  <div class="screen-header">
+    <div class="screen-num">01</div>
+    <div>
+      <div class="screen-title">WelcomeScreen</div>
+      <div class="screen-route">/onboarding/welcome</div>
+    </div>
+  </div>
+  <div style="margin-bottom:10px;">
+    <span class="tag blue">Phase 1 onboarding</span>
+    <span class="tag gray">First launch only</span>
+    <span class="tag gray">No required data</span>
+  </div>
+  <div class="grid">
+    <div class="box"><div class="box-label">States</div><div class="box-content"><ul>
+      <li><strong>Default</strong> — full hero layout</li>
+      <li>No loading, error, or empty states needed</li>
+    </ul></div></div>
+    <div class="box"><div class="box-label">Actions</div><div class="box-content"><ul>
+      <li>"Get started" → <code>SignInScreen</code></li>
+      <li>"Sign in" link → <code>SignInScreen</code></li>
+    </ul></div></div>
+  </div>
+  <div class="box" style="margin-bottom:12px;"><div class="box-label">Layout — full height VStack</div><div class="box-content">
+    <strong>Background:</strong> <code>prBackground</code> + radial gradient <code>prBrand 22%→0%</code> at top-center<br>
+    <strong>Wordmark:</strong> "PRLifts" — <code>prDisplayLarge</code> (48pt black rounded) · "PR" = <code>prTextPrimary</code>, "Lifts" = <code>prBrand</code><br>
+    <strong>Blue underline:</strong> 40×3pt pill, <code>prBrand</code>, <code>0 0 12pt brandGlow</code> shadow · margin-top 10pt<br>
+    <strong>Tagline:</strong> "Track every lift. Celebrate every PR." · <code>prDisplayMedium</code> (34pt) · centred · margin-top 32pt<br>
+    <strong>Benefits VStack:</strong> spacing 12pt · margin-top 28pt<br>
+    — Each row: 26×26 circle (<code>prSuccessBg</code>) + checkmark SF Symbol + 15pt body text<br>
+    <strong>Get started button:</strong> <code>PRButton(.primary)</code> · width fill · margin-top 36pt<br>
+    <strong>Sign in link:</strong> 14pt · margin-top 14pt · centred<br>
+    <strong>Terms caption:</strong> 11pt <code>prTextTertiary</code> · pinned to bottom safe area
+  </div></div>
+  <div class="callout blue">Not shown on subsequent launches. Gate with a <code>hasCompletedOnboarding</code> flag in UserDefaults (or SwiftData User record).</div>
+</div>
+
+<!-- ── 02 SignInScreen ────────────────────────────────────────────── -->
+<div class="screen" id="s02">
+  <div class="screen-header">
+    <div class="screen-num">02</div>
+    <div><div class="screen-title">SignInScreen</div><div class="screen-route">/onboarding/sign-in</div></div>
+  </div>
+  <div style="margin-bottom:10px;">
+    <span class="tag blue">Phase 1 onboarding</span>
+    <span class="tag gray">No required data</span>
+  </div>
+  <div class="grid">
+    <div class="box"><div class="box-label">States</div><div class="box-content"><ul>
+      <li><strong>Default</strong> — all options visible</li>
+      <li><strong>Error</strong> — inline banner below options</li>
+      <li><strong>Loading</strong> — button shows spinner while auth in flight</li>
+      <li><strong>Network unavailable</strong> — inline error, retry button</li>
+    </ul></div></div>
+    <div class="box"><div class="box-label">Error messages</div><div class="box-content"><ul>
+      <li>Invalid credentials: "Sign in failed. Please try again."</li>
+      <li>Network: "No internet connection. Check your settings."</li>
+      <li>Apple/Google failure: "Sign in with [provider] failed. Try another method."</li>
+    </ul></div></div>
+  </div>
+  <div class="box" style="margin-bottom:12px;"><div class="box-label">Layout</div><div class="box-content">
+    <strong>NavBar:</strong> empty (no title, no back button) · no divider<br>
+    <strong>Title:</strong> "Sign in to PRLifts" · <code>prDisplayMedium</code> (34pt) · margin-top 12pt<br>
+    <strong>Subtitle:</strong> "Create an account or sign in to continue" · <code>prBodySecondary</code> · <code>prTextSecondary</code><br>
+    <strong>Apple button:</strong> height 52pt · <code>prTextPrimary</code> background · <code>prBackground</code> text · Apple logo SF Symbol <code>apple.logo</code> · margin-top 32pt<br>
+    <strong>Google button:</strong> height 52pt · <code>prBackgroundSec</code> bg · <code>prBorder</code> stroke 1.5pt · Google G logo (bundled asset)<br>
+    <strong>Divider:</strong> "or continue with email" · 13pt <code>prTextTertiary</code> · margin-top/bottom 20pt<br>
+    <strong>Email input:</strong> <code>PRTextFieldStyle</code> · height 48pt · <code>prBackgroundTer</code> bg · keyboard .emailAddress<br>
+    <strong>Continue button:</strong> <code>PRButton(.primary)</code> · margin-top 12pt<br>
+    <strong>Error banner:</strong> <code>prErrorBg</code> + <code>prError 40%</code> border · appears above Terms with spring animation<br>
+    <strong>Terms:</strong> 12pt · bottom safe area · "Terms" and "Privacy Policy" tappable in <code>prBrandLight</code>
+  </div></div>
+  <div class="callout blue">Handles both new account creation and returning user sign-in from the same screen. After successful auth, check if display_name is set. If set → <code>HomeScreen</code>. If not → <code>DisplayNameScreen</code>.</div>
+</div>
+
+<!-- ── 03 DisplayNameScreen ───────────────────────────────────────── -->
+<div class="screen" id="s03">
+  <div class="screen-header">
+    <div class="screen-num">03</div>
+    <div><div class="screen-title">DisplayNameScreen</div><div class="screen-route">/onboarding/display-name</div></div>
+  </div>
+  <div style="margin-bottom:10px;"><span class="tag blue">Phase 1 onboarding</span><span class="tag gray">Step 3 of 4</span></div>
+  <div class="grid">
+    <div class="box"><div class="box-label">States</div><div class="box-content"><ul>
+      <li><strong>Empty</strong> — cursor in field, Continue disabled</li>
+      <li><strong>Filled</strong> — Continue enabled (shown in spec)</li>
+      <li><strong>Error</strong> — inline "Please enter a display name" if Continue tapped while empty</li>
+    </ul></div></div>
+    <div class="box"><div class="box-label">Validation</div><div class="box-content"><ul>
+      <li>Min: 1 character</li>
+      <li>Max: 50 characters</li>
+      <li>Prefill from auth provider display name if available</li>
+      <li>Cannot be skipped — no skip option</li>
+    </ul></div></div>
+  </div>
+  <div class="box" style="margin-bottom:12px;"><div class="box-label">Layout</div><div class="box-content">
+    <strong>NavBar:</strong> back chevron → SignInScreen · no title<br>
+    <strong>PRProgressDots:</strong> total=4 current=3 · margin-top 28pt<br>
+    <strong>Headline:</strong> "What should we call you?" · <code>prDisplayMedium</code> · margin-top 0<br>
+    <strong>Subtitle:</strong> "This is how you'll appear across your PRLifts profile." · <code>prBodySecondary</code> · <code>prTextSecondary</code><br>
+    <strong>Field label:</strong> "Display name" · 13pt semibold · <code>prTextSecondary</code> · margin-top 36pt<br>
+    <strong>Input:</strong> height 52pt · <code>prBackgroundTer</code> bg · focused: 2pt <code>prBrandLight</code> border + <code>prBrandSubtle</code> outer glow · cursor blinking<br>
+    <strong>Character hint:</strong> "Up to 50 characters" · 12pt <code>prTextTertiary</code> · margin-top 6pt<br>
+    <strong>Continue:</strong> <code>PRButton(.primary)</code> · margin-top 36pt · disabled until valid<br>
+    <strong>Step label:</strong> "Step 3 of 4" · 14pt <code>prTextTertiary</code> · pinned bottom
+  </div></div>
+</div>
+
+<!-- ── 04 UnitPreferenceScreen ────────────────────────────────────── -->
+<div class="screen" id="s04">
+  <div class="screen-header">
+    <div class="screen-num">04</div>
+    <div><div class="screen-title">UnitPreferenceScreen</div><div class="screen-route">/onboarding/units</div></div>
+  </div>
+  <div style="margin-bottom:10px;"><span class="tag blue">Phase 1 onboarding</span><span class="tag gray">Step 4 of 4</span><span class="tag gray">US default: lbs/in</span></div>
+  <div class="box" style="margin-bottom:12px;"><div class="box-label">Layout</div><div class="box-content">
+    <strong>NavBar:</strong> back → DisplayNameScreen · no title<br>
+    <strong>PRProgressDots:</strong> total=4 current=4<br>
+    <strong>Headline:</strong> "How do you measure?" · <code>prDisplayMedium</code><br>
+    <strong>Subtitle:</strong> "You can change this anytime in settings." · margin-bottom 32pt<br>
+    <strong>Section label:</strong> "Weight" · 13pt bold <code>prTextTertiary</code> uppercase · letter-spacing 0.6pt<br>
+    <strong>Unit cards (HStack, gap 10pt):</strong> each card flex:1 · height ~90pt · corner radius 16pt<br>
+    — Selected: <code>prBrand 18%</code> bg · 2pt <code>prBrand</code> border · outer 1pt solid <code>prBrand</code> glow<br>
+    — Unselected: <code>prBackgroundSec</code> · 1pt <code>prBorder</code> border<br>
+    — Label: <code>prDisplayMedium</code> (28pt rounded) · selected: <code>prBrand</code> / unselected: <code>prTextSecondary</code><br>
+    — Sublabel: 13pt · selected: <code>prBrandLight</code> / unselected: <code>prTextTertiary</code><br>
+    <strong>Height section:</strong> same pattern · margin-top 24pt<br>
+    <strong>Continue:</strong> "Start tracking" · <code>PRButton(.primary)</code> · margin-top 36pt<br>
+    <strong>Step label:</strong> "Step 4 of 4 — almost there" · pinned bottom
+  </div></div>
+  <div class="callout blue">Default selection: locale-based. <code>Locale.current.measurementSystem</code> → <code>.metric</code> → kg/cm. <code>.us</code> → lbs/in. Store as <code>User.weightUnit</code> and <code>User.heightUnit</code> after Continue.</div>
+</div>
+
+<!-- ── 05 HomeScreen ──────────────────────────────────────────────── -->
+<div class="screen" id="s05">
+  <div class="screen-header">
+    <div class="screen-num">05</div>
+    <div><div class="screen-title">HomeScreen</div><div class="screen-route">/home</div></div>
+  </div>
+  <div style="margin-bottom:10px;"><span class="tag blue">Main app</span><span class="tag gray">Primary landing screen</span></div>
+  <div class="grid">
+    <div class="box"><div class="box-label">Required data</div><div class="box-content"><ul>
+      <li>User.displayName, User.currentStreak</li>
+      <li>Last 2 PersonalRecords (exercise name, value, unit, delta, date)</li>
+      <li>Aggregate: totalWorkouts, totalPRs</li>
+      <li>FutureSelfImage URL (optional — hide card if nil + no consent)</li>
+    </ul></div></div>
+    <div class="box"><div class="box-label">States</div><div class="box-content"><ul>
+      <li><strong>Loading</strong> — skeleton cards for streak + PRs + stats</li>
+      <li><strong>Empty (no workouts)</strong> — replace PR list with PREmptyState: barbell icon, "No workouts yet", "Log your first workout" CTA</li>
+      <li><strong>Populated</strong> — shown in spec</li>
+      <li><strong>Offline</strong> — OfflineBanner at top</li>
+    </ul></div></div>
+  </div>
+  <div class="box" style="margin-bottom:12px;"><div class="box-label">Layout — ScrollView VStack gap 10pt, horizontal padding 16pt</div><div class="box-content">
+    <strong>NavBar:</strong> "PRLifts" wordmark <code>prHeadlineLarge</code> rounded + user avatar circle right (32×32pt, <code>prBackgroundTer</code>)<br>
+    <strong>Streak card:</strong> <code>PRCard</code> · gradient bg <code>prBrand 22%→8%</code> · border <code>prBrand 40%</code> · icon 48×48pt rounded-14 <code>prBrand</code> · text: greeting 13pt + "X-day streak" <code>prHeadlineLarge</code> · streak bar 7 pills 4pt tall below<br>
+    <strong>Start workout:</strong> <code>PRButton(.primary)</code> · plus icon<br>
+    <strong>Stats grid:</strong> HStack gap 8pt · 2 <code>PRCard</code>s · value <code>prDataLarge</code> in brand/accent · label 12pt <code>prTextSecondary</code><br>
+    <strong>Section header:</strong> "Recent PRs" <code>prHeadlineLarge</code> + "See all →" 13pt <code>prBrandLight</code><br>
+    <strong>PR rows:</strong> <code>PRCard</code> · trophy circle 38×38pt gold gradient · exercise name 15pt bold + date 12pt sec · value <code>prDataMedium</code> + delta 12pt <code>prSuccess</code><br>
+    <strong>Future Self card:</strong> <code>PRCard</code> · gold gradient bg subtle · accent label + subtitle + play arrow icon right
+  </div></div>
+</div>
+
+<!-- ── 06 ActiveWorkoutScreen ─────────────────────────────────────── -->
+<div class="screen" id="s06">
+  <div class="screen-header">
+    <div class="screen-num">06</div>
+    <div><div class="screen-title">ActiveWorkoutScreen</div><div class="screen-route">/workout/active</div></div>
+  </div>
+  <div style="margin-bottom:10px;"><span class="tag blue">Core flow</span><span class="tag gold">PR detection per set</span><span class="tag mint">Offline-capable</span></div>
+  <div class="grid">
+    <div class="box"><div class="box-label">Required data</div><div class="box-content"><ul>
+      <li>Workout (status: in_progress/paused)</li>
+      <li>WorkoutExercises ordered list</li>
+      <li>WorkoutSets for current exercise</li>
+      <li>Timer (elapsed seconds)</li>
+      <li>PersonalRecord (if just detected)</li>
+    </ul></div></div>
+    <div class="box"><div class="box-label">States</div><div class="box-content"><ul>
+      <li><strong>Default</strong> — no PR banner visible</li>
+      <li><strong>PR detected</strong> — banner appears (spring animation)</li>
+      <li><strong>Offline</strong> — OfflineBanner, sets save locally</li>
+      <li><strong>Set logging</strong> — inputs active, Log set button enabled</li>
+    </ul></div></div>
+  </div>
+  <div class="box" style="margin-bottom:12px;"><div class="box-label">Layout</div><div class="box-content">
+    <strong>NavBar:</strong> "Cancel" 14pt <code>prBrandLight</code> left · workout name centred · timer <code>prDataSmall</code> <code>prSuccess</code> right<br>
+    <strong>PRNotificationBanner:</strong> shown when <code>currentPR != nil</code> · margin 10pt horizontal · spring in from top<br>
+    — "Demo" chip right: 13pt · <code>prBackgroundTer</code> · taps → ExerciseDetailScreen (modal)<br>
+    <strong>Set table PRCard:</strong> header row + set rows<br>
+    — Set row: set# <code>prDataSmall</code> <code>prTextSecondary</code> · weight <code>prDataMedium</code> (gold if PR row) · reps <code>prDataMedium</code> · status icon (checkmark circle or 🏆)<br>
+    — PR row background: <code>prAccent 6%</code><br>
+    <strong>Set input PRCard:</strong> "Set N" label · weight + reps inputs HStack · Log set <code>PRButton(.primary)</code> height 44pt<br>
+    <strong>Add exercise row:</strong> dashed border <code>prBorder</code> · 48pt height · taps → ExerciseLibraryScreen (sheet)<br>
+    <strong>Bottom bar:</strong> "Finish workout" <code>PRButton(.primary)</code> height 48pt · border-top <code>prBorder</code>
+  </div></div>
+  <div class="callout mint">All set writes go to SwiftData first (offline-first). PR detection runs in Core Library after each <code>isCompleted = true</code> set. Never call backend directly from this screen.</div>
+</div>
+
+<!-- ── 07 WorkoutSummaryScreen ────────────────────────────────────── -->
+<div class="screen" id="s07">
+  <div class="screen-header">
+    <div class="screen-num">07</div>
+    <div><div class="screen-title">WorkoutSummaryScreen</div><div class="screen-route">/workout/complete</div></div>
+  </div>
+  <div style="margin-bottom:10px;"><span class="tag blue">Core flow</span><span class="tag gold">Gold celebration only here</span><span class="tag mint">Mint for deltas</span></div>
+  <div class="grid">
+    <div class="box"><div class="box-label">Required data</div><div class="box-content"><ul>
+      <li>Completed Workout + all WorkoutSets</li>
+      <li>PersonalRecords[] detected this workout</li>
+      <li>AI insight Job ID (polls until complete)</li>
+      <li>Stats: duration, exercise count, set count, total volume</li>
+    </ul></div></div>
+    <div class="box"><div class="box-label">AI insight states</div><div class="box-content"><ul>
+      <li><strong>Polling</strong> — skeleton shimmer + progressive messages: "Analyzing your workout…" → "Building your insight…"</li>
+      <li><strong>Complete</strong> — insight text appears (spring fade in)</li>
+      <li><strong>Timeout / unavailable</strong> — "Insight unavailable. Try again later." No error UI — just quiet fallback text.</li>
+    </ul></div></div>
+  </div>
+  <div class="box" style="margin-bottom:12px;"><div class="box-label">Layout — ScrollView VStack</div><div class="box-content">
+    <strong>Celebration header:</strong> background gradient <code>celGlow 0%→transparent</code> · "🏆" 52pt emoji · "Workout complete!" <code>prDisplayMedium</code> · date/name caption<br>
+    <strong>Stats 2×2 grid:</strong> 4 <code>PRCard</code>s · value <code>prDataLarge</code> <code>prTextPrimary</code> · label 12pt sec<br>
+    <strong>PR section (gold treatment):</strong> outer border <code>prAccent 40%</code> · header row: <code>celStart→celEnd gradient bg 18%</code> · "🏆 Personal Records" label + count badge (gold gradient pill)<br>
+    — PR rows: <code>celStart 6%</code> background · trophy icon gold gradient · exercise + previous · value <code>prDataMedium</code> <code>prAccent</code> · delta 12pt <code>prSuccess</code><br>
+    <strong>AI insight PRCard:</strong> brain icon + "AI Insight" label 11pt uppercase <code>prBrandLight</code> · 14pt body text or skeleton<br>
+    <strong>Done:</strong> <code>PRButton(.primary)</code> · "View workout details" ghost below
+  </div></div>
+  <div class="callout gold">Gold gradient appears ONLY in the PR section. All positive delta values use <code>prSuccess</code> (mint), not gold. The 🏆 emoji is permitted here (defined celebration moment).</div>
+</div>
+
+<!-- ── 08 PRDetailScreen ──────────────────────────────────────────── -->
+<div class="screen" id="s08">
+  <div class="screen-header">
+    <div class="screen-num">08</div>
+    <div><div class="screen-title">PRDetailScreen</div><div class="screen-route">/records/detail/{record_id}</div></div>
+  </div>
+  <div style="margin-bottom:10px;"><span class="tag blue">Core app</span></div>
+  <div class="grid">
+    <div class="box"><div class="box-label">Required data</div><div class="box-content"><ul>
+      <li>PersonalRecord (value, unit, recorded_at)</li>
+      <li>Previous PersonalRecord (value)</li>
+      <li>Exercise (name, primaryMuscle, equipment)</li>
+      <li>PR history for this exercise: last 5 records</li>
+    </ul></div></div>
+    <div class="box"><div class="box-label">Layout measurements</div><div class="box-content"><ul>
+      <li>Hero PR value: <code>prDisplayLarge</code> 64pt</li>
+      <li>Exercise name: <code>prHeadlineLarge</code> 22pt <code>prTextSecondary</code></li>
+      <li>Date badge: gold gradient pill · 12pt bold</li>
+      <li>Chart height: 80pt · 5 bars · gap 8pt</li>
+      <li>Current bar: gold gradient + <code>accentGlow</code> shadow</li>
+      <li>Past bars: <code>prBrand 40%</code></li>
+    </ul></div></div>
+  </div>
+  <div class="box"><div class="box-label">Chart implementation</div><div class="box-content">
+    Use SwiftUI Charts (iOS 16+). Bar chart, 5 most recent PRs for this exercise.<br>
+    Current PR bar: <code>LinearGradient(prCelebrationStart→prCelebrationEnd, vertical)</code> · shadow <code>accentGlow</code><br>
+    Past bars: <code>prBrand.opacity(0.40)</code> · no shadow<br>
+    Y-axis: hidden (values shown above each bar as caption) · X-axis: month abbreviation labels
+  </div></div>
+</div>
+
+<!-- ── 09 ExerciseDetailScreen ────────────────────────────────────── -->
+<div class="screen" id="s09">
+  <div class="screen-header">
+    <div class="screen-num">09</div>
+    <div><div class="screen-title">ExerciseDetailScreen</div><div class="screen-route">/exercises/detail/{exercise_id}</div></div>
+  </div>
+  <div style="margin-bottom:10px;"><span class="tag blue">Exercise library</span><span class="tag gold">4 artboard states</span></div>
+  <div class="grid">
+    <div class="box"><div class="box-label">Required data</div><div class="box-content"><ul>
+      <li>Exercise (name, primaryMuscle, secondaryMuscles[], equipment, instructions[])</li>
+      <li>demo_url (optional — ExerciseDB video URL)</li>
+      <li>User's PR for this exercise (optional — shown if exists)</li>
+      <li>Boolean: isActiveWorkoutInProgress (controls CTA)</li>
+    </ul></div></div>
+    <div class="box"><div class="box-label">Video player states</div><div class="box-content"><ul>
+      <li><strong>Loading</strong> — placeholder with shimmer</li>
+      <li><strong>Playing</strong> — AVKit VideoPlayer, loop enabled</li>
+      <li><strong>Error / nil URL</strong> → <code>PRBodyDiagram</code> with primary muscle highlighted + "Video unavailable" notice + "View on ExerciseDB →" link</li>
+    </ul></div></div>
+  </div>
+  <div class="box" style="margin-bottom:12px;"><div class="box-label">Layout</div><div class="box-content">
+    <strong>NavBar:</strong> back → exercise library · exercise name centred · ⋯ menu right (share/report)<br>
+    <strong>Video card:</strong> height 200pt · corner radius 16pt · border <code>prBorder</code><br>
+    — Playing state: <code>VideoPlayer</code> · bottom overlay gradient with exercise name + source<br>
+    — Error state: <code>PRBodyDiagram</code> centred + legend + bottom notice bar<br>
+    <strong>Muscles section:</strong> "Muscles" label 11pt · chip row: primary in <code>prBrandSub</code> bg / secondary in <code>prBrandSub 70%</code><br>
+    <strong>Equipment:</strong> inline with muscles section · <code>prBackgroundTer</code> pill<br>
+    <strong>Instructions:</strong> numbered steps · step N circle 22×22pt · body text 13pt <code>prTextSecondary</code> · step 1 circle filled <code>prBrand</code><br>
+    <strong>Bottom bar (contextual CTA):</strong><br>
+    — Active workout: "Add to workout" <code>PRButton(.primary)</code> height 48pt<br>
+    — No active workout: "Start workout with this exercise" <code>PRButton(.primary)</code><br>
+    — Fallback link below: 12pt <code>prBrandLight</code>
+  </div></div>
+  <div class="callout blue">The "Demo" button on <strong>ActiveWorkoutScreen</strong> (06) presents this screen as a modal sheet, not a push navigation. The back button dismisses the sheet and returns to the workout.</div>
+</div>
+
+<!-- ── 10 EditSetSheet ────────────────────────────────────────────── -->
+<div class="screen" id="s10">
+  <div class="screen-header">
+    <div class="screen-num">10</div>
+    <div><div class="screen-title">EditSetSheet</div><div class="screen-route">Inline component — ActiveWorkoutScreen</div></div>
+  </div>
+  <div style="margin-bottom:10px;"><span class="tag blue">Bottom sheet</span><span class="tag warn">PR warning on open</span></div>
+  <div class="grid">
+    <div class="box"><div class="box-label">Trigger</div><div class="box-content">Long-press or swipe-left on any completed set row in the set table. Shows sheet with that set pre-filled.</div></div>
+    <div class="box"><div class="box-label">PR warning rule</div><div class="box-content">Show immediately on sheet appear if the set being edited is the user's current PR for this exercise. No delay. Uses <code>.onAppear</code>, not a save-triggered check.</div></div>
+  </div>
+  <div class="box" style="margin-bottom:12px;"><div class="box-label">Layout — bottom sheet, detent 62% screen height</div><div class="box-content">
+    <strong>Implementation:</strong> <code>.sheet(isPresented:)</code> with <code>.presentationDetents([.fraction(0.62)])</code> · <code>.presentationDragIndicator(.visible)</code> · <code>.presentationBackground(Color.prBackgroundSec)</code><br>
+    <strong>Handle:</strong> system drag indicator (not custom)<br>
+    <strong>Header:</strong> "Edit Set N" <code>prHeadlineLarge</code> · "Cancel" 14pt <code>prBrandLight</code> button right · padding 18pt<br>
+    <strong>PR warning banner:</strong> <code>prWarning 10%</code> bg · <code>prWarning 30%</code> border · warning triangle + "Editing this set will recalculate your personal record" · 13pt · shown on <code>.onAppear</code><br>
+    <strong>Inputs HStack gap 10pt:</strong><br>
+    — Weight field: <code>prBackgroundTer</code> bg · height 50pt · <code>prDataMedium</code> monospaced · focused: 1.5pt <code>prBrandLight</code> border + outer glow<br>
+    — Reps field: same<br>
+    <strong>Save button:</strong> "Save changes" <code>PRButton(.primary)</code> height 48pt · margin 16pt horizontal<br>
+    <strong>Divider:</strong> <code>prBorder</code> · margin 16pt horizontal<br>
+    <strong>Delete set:</strong> "Delete set" 15pt bold <code>prError</code> · centred · taps → confirmation alert (not another sheet)
+  </div></div>
+  <div class="callout warn">Delete set confirmation: use SwiftUI <code>.alert("Delete set?", isPresented:)</code> with destructive button "Delete" and cancel. Never use a sheet-within-a-sheet.</div>
+</div>
+
+<!-- ── 11 DeleteWorkoutDialog ─────────────────────────────────────── -->
+<div class="screen" id="s11">
+  <div class="screen-header">
+    <div class="screen-num">11</div>
+    <div><div class="screen-title">Delete Workout — Confirmation Dialog</div><div class="screen-route">Inline component — WorkoutSummaryScreen + WorkoutHistoryScreen</div></div>
+  </div>
+  <div style="margin-bottom:10px;"><span class="tag red">Destructive</span><span class="tag gray">Two surfaces</span></div>
+  <div class="grid">
+    <div class="box"><div class="box-label">Surfaces</div><div class="box-content"><ul>
+      <li><strong>WorkoutSummaryScreen</strong> — "Delete workout" option in ⋯ menu or swipe action</li>
+      <li><strong>WorkoutHistoryScreen</strong> — swipe-left on workout row → delete action</li>
+    </ul></div></div>
+    <div class="box"><div class="box-label">Post-deletion</div><div class="box-content"><ul>
+      <li>Dismiss dialog</li>
+      <li>Pop navigation to HomeScreen (if from Summary) or refresh list (if from History)</li>
+      <li>PR recalculation runs in Core Library asynchronously</li>
+    </ul></div></div>
+  </div>
+  <div class="box" style="margin-bottom:12px;"><div class="box-label">Implementation</div><div class="box-content">
+    <strong>Preferred:</strong> SwiftUI <code>.confirmationDialog()</code> — renders as system action sheet on iOS, matches platform HIG.<br>
+    <strong>Custom centered dialog (as shown in spec):</strong> only if product requires custom styling. Use ZStack overlay with <code>.background(.ultraThinMaterial)</code> scrim.
+  </div></div>
+  <pre><span class="cmt">// Option A — native (preferred)</span>
+.<span class="kw">confirmationDialog</span>(
+    <span class="str">"Delete workout?"</span>,
+    isPresented: $showDeleteConfirm,
+    titleVisibility: .visible
+) {
+    <span class="type">Button</span>(<span class="str">"Delete workout"</span>, role: .destructive) { viewModel.deleteWorkout() }
+    <span class="type">Button</span>(<span class="str">"Cancel"</span>, role: .cancel) {}
+} message: {
+    <span class="type">Text</span>(<span class="str">"This will permanently delete this workout and all its sets. Your personal records may be updated."</span>)
+}
+
+<span class="cmt">// Option B — custom (if design requires exact spec visual)</span>
+<span class="kw">if</span> showDeleteConfirm {
+    <span class="type">ZStack</span> {
+        <span class="type">Color</span>.black.opacity(<span class="num">0.58</span>).ignoresSafeArea()
+            .onTapGesture { showDeleteConfirm = <span class="kw">false</span> }
+        <span class="type">PRDeleteDialogCard</span>(
+            onDelete: { viewModel.deleteWorkout(); showDeleteConfirm = <span class="kw">false</span> },
+            onCancel: { showDeleteConfirm = <span class="kw">false</span> }
+        )
+    }
+    .transition(.opacity.animation(<span class="type">PRAnimation</span>.standard))
+}</pre>
+  <div class="callout red">
+    <strong>Never merge PRs without deletion completing successfully.</strong> The <code>deleteWorkout()</code> call must confirm backend deletion before dismissing. Show a loading state on the "Delete workout" button if the delete call takes >0.5s.
+  </div>
+</div>
+
+<!-- Footer -->
+<div style="margin-top:48px;padding-top:24px;border-top:1px solid var(--border);">
+  <p style="color:var(--t3);font-size:12px;">PRLifts Design System v2.0 · Obsidian × Velocity Hybrid · Approved April 2026<br>
+  Source of truth: <a href="8 Screens.html">8 Screens.html</a> (design canvas) · <a href="Handoff Bundle.html">Handoff Bundle.html</a> (tokens + components)</p>
+</div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
Adds the complete Claude Design handoff bundle for all 11 sprint 1 screens.

Files added to design/:
- 8 Screens.html — visual spec for all 11 screens × dark + light (22 artboards 
  + 2 additional states for ExerciseDetailScreen)
- Handoff Bundle.html — SwiftUI token definitions, color extensions, font 
  extensions, spacing/radius/shadow/animation tokens, and copy-ready SwiftUI 
  code for 10 components (PRButton, PRCard, PRNavBar, PRTabBar, 
  PRNotificationBanner, PRBottomSheet, PRConfirmationDialog, PRVideoPlayerCard, 
  PRBodyDiagram, PRProgressDots)
- handoff-screens.html — per-screen layout specs with exact measurements, 
  data bindings, component references, SwiftUI implementation notes, and 
  accessibility requirements
- colors_and_type.css — authoritative v2.0 Hybrid token set for dark and 
  light modes

Design system: Hybrid v2.0 — cool blue-indigo dark backgrounds, lavender 
light backgrounds, brand blue constant across modes, gold reserved exclusively 
for PR achievement moments, mint for positive deltas and sync states.

Claude Code reads Handoff Bundle.html first, then handoff-screens.html for 
the specific screen being built, and references 8 Screens.html as the visual 
source of truth.

Closes issues #17 and #18.