### PR TITLE
[iOS] Core Library SwiftData models for all V1 entities

### DIFF
--- a/PRLiftsCore/Package.swift
+++ b/PRLiftsCore/Package.swift
@@ -1,26 +1,25 @@
 // swift-tools-version: 6.2
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 import PackageDescription
 
 let package = Package(
     name: "PRLiftsCore",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14)
+    ],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
-        .library(
-            name: "PRLiftsCore",
-            targets: ["PRLiftsCore"]
-        ),
+        .library(name: "PRLiftsCore", targets: ["PRLiftsCore"]),
+        .library(name: "PRLiftsCoreTestSupport", targets: ["PRLiftsCoreTestSupport"])
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
+        .target(name: "PRLiftsCore"),
         .target(
-            name: "PRLiftsCore"
+            name: "PRLiftsCoreTestSupport",
+            dependencies: ["PRLiftsCore"]
         ),
         .testTarget(
             name: "PRLiftsCoreTests",
-            dependencies: ["PRLiftsCore"]
-        ),
+            dependencies: ["PRLiftsCore", "PRLiftsCoreTestSupport"]
+        )
     ]
 )

--- a/PRLiftsCore/Sources/PRLiftsCore/Migration/MigrationManager.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Migration/MigrationManager.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public enum MigrationManager {
+    public static let currentVersion = 1
+
+    nonisolated(unsafe) static var userDefaults: UserDefaults = .standard
+
+    private static var inProgressKey: String {
+        "swiftdata_migration_in_progress_v\(currentVersion)"
+    }
+
+    public static var migrationFailed: Bool {
+        userDefaults.bool(forKey: inProgressKey)
+    }
+
+    public static func beginMigration() {
+        userDefaults.set(true, forKey: inProgressKey)
+    }
+
+    public static func completeMigration() {
+        userDefaults.removeObject(forKey: inProgressKey)
+    }
+
+    public static func resetMigrationFlag() {
+        userDefaults.removeObject(forKey: inProgressKey)
+    }
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Migration/PRLiftsSchema.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Migration/PRLiftsSchema.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftData
+
+public enum PRLiftsSchema {
+    public static var models: [any PersistentModel.Type] {
+        [
+            User.self,
+            Exercise.self,
+            Workout.self,
+            WorkoutExercise.self,
+            WorkoutSet.self,
+            PersonalRecord.self,
+            Job.self,
+            SyncEventLog.self
+        ]
+    }
+
+    public static func makeContainer(inMemory: Bool = false) throws -> ModelContainer {
+        MigrationManager.beginMigration()
+        let schema = Schema(models)
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: inMemory)
+        let container = try ModelContainer(for: schema, configurations: config)
+        MigrationManager.completeMigration()
+        return container
+    }
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/Enums.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/Enums.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+public enum WeightUnit: String, Codable, CaseIterable, Hashable, Sendable {
+    case kg
+    case lbs
+}
+
+public enum MeasurementUnit: String, Codable, CaseIterable, Hashable, Sendable {
+    case cm
+    case inches
+}
+
+public enum Gender: String, Codable, CaseIterable, Hashable, Sendable {
+    case male
+    case female
+    case na
+}
+
+public enum UserGoal: String, Codable, CaseIterable, Hashable, Sendable {
+    case buildMuscle = "build_muscle"
+    case loseFat = "lose_fat"
+    case improveEndurance = "improve_endurance"
+    case athleticPerformance = "athletic_performance"
+    case generalFitness = "general_fitness"
+}
+
+public enum BetaTier: String, Codable, CaseIterable, Hashable, Sendable {
+    case none
+    case tester
+    case fullAccess = "full_access"
+}
+
+public enum WorkoutStatus: String, Codable, CaseIterable, Hashable, Sendable {
+    case inProgress = "in_progress"
+    case paused
+    case partialCompletion = "partial_completion"
+    case completed
+}
+
+public enum WorkoutType: String, Codable, CaseIterable, Hashable, Sendable {
+    case adHoc = "ad_hoc"
+    case planned
+}
+
+public enum WorkoutFormat: String, Codable, CaseIterable, Hashable, Sendable {
+    case weightlifting
+    case cardio
+    case mixed
+    case other
+}
+
+public enum WorkoutLocation: String, Codable, CaseIterable, Hashable, Sendable {
+    case gym
+    case home
+    case outdoor
+    case other
+}
+
+public enum SetType: String, Codable, CaseIterable, Hashable, Sendable {
+    case normal
+    case warmup
+    case dropset
+    case failure
+    case pr
+}
+
+public enum WeightModifier: String, Codable, CaseIterable, Hashable, Sendable {
+    case none
+    case assisted
+    case weighted
+}
+
+public enum RecordType: String, Codable, CaseIterable, Hashable, Sendable {
+    case heaviestWeight = "heaviest_weight"
+    case mostReps = "most_reps"
+    case longestDuration = "longest_duration"
+    case longestDistance = "longest_distance"
+    case bestRpe = "best_rpe"
+}
+
+public enum ValueUnit: String, Codable, CaseIterable, Hashable, Sendable {
+    case kg
+    case lbs
+    case reps
+    case seconds
+    case meters
+}
+
+public enum ExerciseCategory: String, Codable, CaseIterable, Hashable, Sendable {
+    case strength
+    case cardio
+    case flexibility
+    case bodyweight
+    case mobility
+    case saq
+    case rehab
+}
+
+public enum ExerciseEquipment: String, Codable, CaseIterable, Hashable, Sendable {
+    case barbell
+    case dumbbell
+    case kettlebell
+    case machine
+    case cable
+    case bodyweight
+    case cardioMachine = "cardio_machine"
+    case other
+}
+
+public enum MuscleGroup: String, Codable, CaseIterable, Hashable, Sendable {
+    case upperChest = "upper_chest"
+    case midChest = "mid_chest"
+    case lowerChest = "lower_chest"
+    case upperBack = "upper_back"
+    case lowerBack = "lower_back"
+    case shoulders
+    case biceps
+    case triceps
+    case quads
+    case hamstrings
+    case calves
+    case glutes
+    case abs
+    case obliques
+    case fullBody = "full_body"
+}
+
+public enum JobStatus: String, Codable, CaseIterable, Hashable, Sendable {
+    case pending
+    case processing
+    case complete
+    case failed
+    case expired
+}
+
+public enum JobType: String, Codable, CaseIterable, Hashable, Sendable {
+    case insight
+    case futureSelf = "future_self"
+    case benchmarking
+}
+
+public enum SyncEventType: String, Codable, CaseIterable, Hashable, Sendable {
+    case writeAttempt = "write_attempt"
+    case syncAttempt = "sync_attempt"
+    case syncSuccess = "sync_success"
+    case syncFailure = "sync_failure"
+    case conflictResolved = "conflict_resolved"
+}
+
+public enum SyncEntityType: String, Codable, CaseIterable, Hashable, Sendable {
+    case workout
+    case workoutExercise = "workout_exercise"
+    case workoutSet = "workout_set"
+    case personalRecord = "personal_record"
+    case bodyMetrics = "body_metrics"
+    case stepsEntry = "steps_entry"
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/Exercise.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/Exercise.swift
@@ -1,0 +1,54 @@
+import Foundation
+import SwiftData
+
+@Model
+public final class Exercise {
+    public var id: UUID
+    public var name: String
+    public var category: ExerciseCategory
+    public var muscleGroup: MuscleGroup
+    public var secondaryMuscleGroups: [MuscleGroup]
+    public var equipment: ExerciseEquipment
+    public var instructions: String?
+    public var demoURL: String?
+    public var isCustom: Bool
+    public var createdBy: UUID?
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    @Relationship(deleteRule: .nullify, inverse: \WorkoutExercise.exercise)
+    public var workoutExercises: [WorkoutExercise]
+
+    @Relationship(deleteRule: .nullify, inverse: \PersonalRecord.exercise)
+    public var personalRecords: [PersonalRecord]
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        category: ExerciseCategory,
+        muscleGroup: MuscleGroup,
+        secondaryMuscleGroups: [MuscleGroup] = [],
+        equipment: ExerciseEquipment,
+        instructions: String? = nil,
+        demoURL: String? = nil,
+        isCustom: Bool = false,
+        createdBy: UUID? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.category = category
+        self.muscleGroup = muscleGroup
+        self.secondaryMuscleGroups = secondaryMuscleGroups
+        self.equipment = equipment
+        self.instructions = instructions
+        self.demoURL = demoURL
+        self.isCustom = isCustom
+        self.createdBy = createdBy
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.workoutExercises = []
+        self.personalRecords = []
+    }
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/Job.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/Job.swift
@@ -1,0 +1,39 @@
+import Foundation
+import SwiftData
+
+@Model
+public final class Job {
+    public var id: UUID
+    public var jobType: JobType
+    public var status: JobStatus
+    public var result: String?
+    public var errorMessage: String?
+    public var startedAt: Date?
+    public var completedAt: Date?
+    public var expiresAt: Date
+    public var createdAt: Date
+
+    public var user: User?
+
+    public init(
+        id: UUID = UUID(),
+        jobType: JobType,
+        status: JobStatus = .pending,
+        result: String? = nil,
+        errorMessage: String? = nil,
+        startedAt: Date? = nil,
+        completedAt: Date? = nil,
+        expiresAt: Date = Date().addingTimeInterval(300),
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.jobType = jobType
+        self.status = status
+        self.result = result
+        self.errorMessage = errorMessage
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.expiresAt = expiresAt
+        self.createdAt = createdAt
+    }
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/PersonalRecord.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/PersonalRecord.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SwiftData
+
+@Model
+public final class PersonalRecord {
+    public var id: UUID
+    public var weightModifier: WeightModifier
+    public var recordType: RecordType
+    public var value: Double
+    public var valueUnit: ValueUnit?
+    public var recordedAt: Date
+    public var previousValue: Double?
+    public var previousRecordedAt: Date?
+    // Stored as UUID rather than a SwiftData relationship — PR records the triggering set
+    // but does not own it. The set can be edited without invalidating the PR record.
+    public var workoutSetID: UUID
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public var user: User?
+    public var exercise: Exercise?
+
+    public init(
+        id: UUID = UUID(),
+        weightModifier: WeightModifier,
+        recordType: RecordType,
+        value: Double,
+        valueUnit: ValueUnit? = nil,
+        recordedAt: Date,
+        previousValue: Double? = nil,
+        previousRecordedAt: Date? = nil,
+        workoutSetID: UUID,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.weightModifier = weightModifier
+        self.recordType = recordType
+        self.value = value
+        self.valueUnit = valueUnit
+        self.recordedAt = recordedAt
+        self.previousValue = previousValue
+        self.previousRecordedAt = previousRecordedAt
+        self.workoutSetID = workoutSetID
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/SyncEventLog.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/SyncEventLog.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SwiftData
+
+@Model
+public final class SyncEventLog {
+    public var id: UUID
+    public var eventType: SyncEventType
+    public var entityType: SyncEntityType
+    public var entityID: UUID
+    public var detail: String?
+    public var occurredAt: Date
+    public var uploadedAt: Date?
+
+    public var user: User?
+
+    public init(
+        id: UUID = UUID(),
+        eventType: SyncEventType,
+        entityType: SyncEntityType,
+        entityID: UUID,
+        detail: String? = nil,
+        occurredAt: Date = Date(),
+        uploadedAt: Date? = nil
+    ) {
+        self.id = id
+        self.eventType = eventType
+        self.entityType = entityType
+        self.entityID = entityID
+        self.detail = detail
+        self.occurredAt = occurredAt
+        self.uploadedAt = uploadedAt
+    }
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/User.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/User.swift
@@ -1,0 +1,65 @@
+import Foundation
+import SwiftData
+
+@Model
+public final class User {
+    public var id: UUID
+    public var email: String?
+    public var displayName: String?
+    public var avatarURL: String?
+    public var unitPreference: WeightUnit
+    public var measurementUnit: MeasurementUnit
+    public var dateOfBirth: Date?
+    public var gender: Gender
+    public var goal: UserGoal?
+    public var phase2CompletedAt: Date?
+    public var betaTier: BetaTier
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    @Relationship(deleteRule: .cascade, inverse: \Workout.user)
+    public var workouts: [Workout]
+
+    @Relationship(deleteRule: .cascade, inverse: \PersonalRecord.user)
+    public var personalRecords: [PersonalRecord]
+
+    @Relationship(deleteRule: .cascade, inverse: \Job.user)
+    public var jobs: [Job]
+
+    @Relationship(deleteRule: .cascade, inverse: \SyncEventLog.user)
+    public var syncEventLogs: [SyncEventLog]
+
+    public init(
+        id: UUID = UUID(),
+        email: String? = nil,
+        displayName: String? = nil,
+        avatarURL: String? = nil,
+        unitPreference: WeightUnit = .lbs,
+        measurementUnit: MeasurementUnit = .cm,
+        dateOfBirth: Date? = nil,
+        gender: Gender = .na,
+        goal: UserGoal? = nil,
+        phase2CompletedAt: Date? = nil,
+        betaTier: BetaTier = .none,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.email = email
+        self.displayName = displayName
+        self.avatarURL = avatarURL
+        self.unitPreference = unitPreference
+        self.measurementUnit = measurementUnit
+        self.dateOfBirth = dateOfBirth
+        self.gender = gender
+        self.goal = goal
+        self.phase2CompletedAt = phase2CompletedAt
+        self.betaTier = betaTier
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.workouts = []
+        self.personalRecords = []
+        self.jobs = []
+        self.syncEventLogs = []
+    }
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/Workout.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/Workout.swift
@@ -1,0 +1,58 @@
+import Foundation
+import SwiftData
+
+@Model
+public final class Workout {
+    public var id: UUID
+    public var name: String?
+    public var notes: String?
+    public var status: WorkoutStatus
+    public var type: WorkoutType
+    public var format: WorkoutFormat
+    public var startedAt: Date
+    public var completedAt: Date?
+    public var durationSeconds: Int?
+    public var location: WorkoutLocation?
+    public var rating: Int?
+    public var serverReceivedAt: Date
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public var user: User?
+
+    @Relationship(deleteRule: .cascade, inverse: \WorkoutExercise.workout)
+    public var exercises: [WorkoutExercise]
+
+    public init(
+        id: UUID = UUID(),
+        name: String? = nil,
+        notes: String? = nil,
+        status: WorkoutStatus = .inProgress,
+        type: WorkoutType,
+        format: WorkoutFormat,
+        startedAt: Date = Date(),
+        completedAt: Date? = nil,
+        durationSeconds: Int? = nil,
+        location: WorkoutLocation? = nil,
+        rating: Int? = nil,
+        serverReceivedAt: Date = Date(),
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.notes = notes
+        self.status = status
+        self.type = type
+        self.format = format
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.durationSeconds = durationSeconds
+        self.location = location
+        self.rating = rating
+        self.serverReceivedAt = serverReceivedAt
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.exercises = []
+    }
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/WorkoutExercise.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/WorkoutExercise.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SwiftData
+
+@Model
+public final class WorkoutExercise {
+    public var id: UUID
+    public var orderIndex: Int
+    public var notes: String?
+    public var restSeconds: Int?
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public var workout: Workout?
+    public var exercise: Exercise?
+
+    @Relationship(deleteRule: .cascade, inverse: \WorkoutSet.workoutExercise)
+    public var sets: [WorkoutSet]
+
+    public init(
+        id: UUID = UUID(),
+        orderIndex: Int,
+        notes: String? = nil,
+        restSeconds: Int? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.orderIndex = orderIndex
+        self.notes = notes
+        self.restSeconds = restSeconds
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.sets = []
+    }
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/WorkoutSet.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/WorkoutSet.swift
@@ -1,0 +1,66 @@
+import Foundation
+import SwiftData
+
+@Model
+public final class WorkoutSet {
+    public var id: UUID
+    public var setNumber: Int
+    public var setType: SetType
+    public var weight: Double?
+    public var weightUnit: WeightUnit?
+    public var weightModifier: WeightModifier
+    public var modifierValue: Double?
+    public var modifierUnit: WeightUnit?
+    public var reps: Int?
+    public var durationSeconds: Int?
+    public var distanceMeters: Double?
+    public var calories: Int?
+    public var rpe: Int?
+    public var isCompleted: Bool
+    public var notes: String?
+    public var serverReceivedAt: Date
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public var workoutExercise: WorkoutExercise?
+
+    public init(
+        id: UUID = UUID(),
+        setNumber: Int,
+        setType: SetType = .normal,
+        weight: Double? = nil,
+        weightUnit: WeightUnit? = nil,
+        weightModifier: WeightModifier = .none,
+        modifierValue: Double? = nil,
+        modifierUnit: WeightUnit? = nil,
+        reps: Int? = nil,
+        durationSeconds: Int? = nil,
+        distanceMeters: Double? = nil,
+        calories: Int? = nil,
+        rpe: Int? = nil,
+        isCompleted: Bool = false,
+        notes: String? = nil,
+        serverReceivedAt: Date = Date(),
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.setNumber = setNumber
+        self.setType = setType
+        self.weight = weight
+        self.weightUnit = weightUnit
+        self.weightModifier = weightModifier
+        self.modifierValue = modifierValue
+        self.modifierUnit = modifierUnit
+        self.reps = reps
+        self.durationSeconds = durationSeconds
+        self.distanceMeters = distanceMeters
+        self.calories = calories
+        self.rpe = rpe
+        self.isCompleted = isCompleted
+        self.notes = notes
+        self.serverReceivedAt = serverReceivedAt
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/PRLiftsCore.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/PRLiftsCore.swift
@@ -1,2 +1,2 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
+// PRLifts Core Library — SwiftData models and business logic.
+// Architecture placement: Core Library layer. No UIKit, no SwiftUI.

--- a/PRLiftsCore/Sources/PRLiftsCoreTestSupport/ModelStubs.swift
+++ b/PRLiftsCore/Sources/PRLiftsCoreTestSupport/ModelStubs.swift
@@ -1,0 +1,173 @@
+import Foundation
+import PRLiftsCore
+import SwiftData
+
+public extension User {
+    static func stub(
+        id: UUID = UUID(),
+        email: String? = "stub@example.com",
+        displayName: String? = "Stub User",
+        unitPreference: WeightUnit = .lbs,
+        measurementUnit: MeasurementUnit = .cm,
+        gender: Gender = .na,
+        goal: UserGoal? = nil,
+        betaTier: BetaTier = .none
+    ) -> User {
+        User(
+            id: id,
+            email: email,
+            displayName: displayName,
+            unitPreference: unitPreference,
+            measurementUnit: measurementUnit,
+            gender: gender,
+            goal: goal,
+            betaTier: betaTier
+        )
+    }
+}
+
+public extension Exercise {
+    static func stub(
+        id: UUID = UUID(),
+        name: String = "Bench Press",
+        category: ExerciseCategory = .strength,
+        muscleGroup: MuscleGroup = .midChest,
+        secondaryMuscleGroups: [MuscleGroup] = [.shoulders, .triceps],
+        equipment: ExerciseEquipment = .barbell,
+        isCustom: Bool = false
+    ) -> Exercise {
+        Exercise(
+            id: id,
+            name: name,
+            category: category,
+            muscleGroup: muscleGroup,
+            secondaryMuscleGroups: secondaryMuscleGroups,
+            equipment: equipment,
+            isCustom: isCustom
+        )
+    }
+}
+
+public extension Workout {
+    static func stub(
+        id: UUID = UUID(),
+        name: String? = "Morning Session",
+        status: WorkoutStatus = .inProgress,
+        type: WorkoutType = .adHoc,
+        format: WorkoutFormat = .weightlifting,
+        location: WorkoutLocation? = .gym
+    ) -> Workout {
+        Workout(
+            id: id,
+            name: name,
+            status: status,
+            type: type,
+            format: format,
+            location: location
+        )
+    }
+}
+
+public extension WorkoutExercise {
+    static func stub(
+        id: UUID = UUID(),
+        orderIndex: Int = 0,
+        restSeconds: Int? = 90
+    ) -> WorkoutExercise {
+        WorkoutExercise(
+            id: id,
+            orderIndex: orderIndex,
+            restSeconds: restSeconds
+        )
+    }
+}
+
+public extension WorkoutSet {
+    static func stub(
+        id: UUID = UUID(),
+        setNumber: Int = 1,
+        setType: SetType = .normal,
+        weight: Double? = 100.0,
+        weightUnit: WeightUnit? = .lbs,
+        reps: Int? = 10,
+        isCompleted: Bool = true
+    ) -> WorkoutSet {
+        WorkoutSet(
+            id: id,
+            setNumber: setNumber,
+            setType: setType,
+            weight: weight,
+            weightUnit: weightUnit,
+            reps: reps,
+            isCompleted: isCompleted
+        )
+    }
+}
+
+public extension PersonalRecord {
+    static func stub(
+        id: UUID = UUID(),
+        weightModifier: WeightModifier = .none,
+        recordType: RecordType = .heaviestWeight,
+        value: Double = 225.0,
+        valueUnit: ValueUnit? = .lbs,
+        recordedAt: Date = Date(),
+        previousValue: Double? = 205.0,
+        workoutSetID: UUID = UUID()
+    ) -> PersonalRecord {
+        PersonalRecord(
+            id: id,
+            weightModifier: weightModifier,
+            recordType: recordType,
+            value: value,
+            valueUnit: valueUnit,
+            recordedAt: recordedAt,
+            previousValue: previousValue,
+            workoutSetID: workoutSetID
+        )
+    }
+}
+
+public extension Job {
+    static func stub(
+        id: UUID = UUID(),
+        jobType: JobType = .insight,
+        status: JobStatus = .pending,
+        expiresAt: Date = Date().addingTimeInterval(300)
+    ) -> Job {
+        Job(
+            id: id,
+            jobType: jobType,
+            status: status,
+            expiresAt: expiresAt
+        )
+    }
+}
+
+public extension SyncEventLog {
+    static func stub(
+        id: UUID = UUID(),
+        eventType: SyncEventType = .writeAttempt,
+        entityType: SyncEntityType = .workout,
+        entityID: UUID = UUID(),
+        detail: String? = nil,
+        occurredAt: Date = Date()
+    ) -> SyncEventLog {
+        SyncEventLog(
+            id: id,
+            eventType: eventType,
+            entityType: entityType,
+            entityID: entityID,
+            detail: detail,
+            occurredAt: occurredAt
+        )
+    }
+}
+
+public enum TestContainerFactory {
+    public static func make() throws -> ModelContainer {
+        let schema = Schema(PRLiftsSchema.models)
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: config)
+    }
+}

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/Migration/MigrationManagerTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/Migration/MigrationManagerTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+@testable import PRLiftsCore
+import XCTest
+
+final class MigrationManagerTests: XCTestCase {
+    var testDefaults: UserDefaults!
+    let testSuiteName = "com.prlifts.test.migrationmanager"
+
+    override func setUp() {
+        super.setUp()
+        testDefaults = UserDefaults(suiteName: testSuiteName)
+        testDefaults.removePersistentDomain(forName: testSuiteName)
+        MigrationManager.userDefaults = testDefaults
+    }
+
+    override func tearDown() {
+        testDefaults.removePersistentDomain(forName: testSuiteName)
+        MigrationManager.userDefaults = .standard
+        testDefaults = nil
+        super.tearDown()
+    }
+
+    func testInitialStateIsNotFailed() {
+        XCTAssertFalse(MigrationManager.migrationFailed)
+    }
+
+    func testBeginMigrationSetsFlag() {
+        MigrationManager.beginMigration()
+        XCTAssertTrue(MigrationManager.migrationFailed)
+    }
+
+    func testCompleteMigrationClearsFlag() {
+        MigrationManager.beginMigration()
+        MigrationManager.completeMigration()
+        XCTAssertFalse(MigrationManager.migrationFailed)
+    }
+
+    func testResetMigrationFlagClearsFlag() {
+        MigrationManager.beginMigration()
+        MigrationManager.resetMigrationFlag()
+        XCTAssertFalse(MigrationManager.migrationFailed)
+    }
+
+    func testFlagPersistsWithoutCompletion() {
+        MigrationManager.beginMigration()
+        // Simulate app relaunch by re-reading from the same UserDefaults
+        XCTAssertTrue(MigrationManager.migrationFailed)
+    }
+
+    func testMultipleBeginCallsDoNotBreakCompletion() {
+        MigrationManager.beginMigration()
+        MigrationManager.beginMigration()
+        MigrationManager.completeMigration()
+        XCTAssertFalse(MigrationManager.migrationFailed)
+    }
+
+    func testCompletionWithoutBeginIsNoOp() {
+        MigrationManager.completeMigration()
+        XCTAssertFalse(MigrationManager.migrationFailed)
+    }
+
+    func testCurrentVersionIsPositive() {
+        XCTAssertGreaterThan(MigrationManager.currentVersion, 0)
+    }
+
+    func testBeginAndCompleteAreSymmetric() {
+        XCTAssertFalse(MigrationManager.migrationFailed)
+        MigrationManager.beginMigration()
+        XCTAssertTrue(MigrationManager.migrationFailed)
+        MigrationManager.completeMigration()
+        XCTAssertFalse(MigrationManager.migrationFailed)
+    }
+
+    func testResetAfterSuccessfulMigrationIsNoOp() {
+        MigrationManager.beginMigration()
+        MigrationManager.completeMigration()
+        MigrationManager.resetMigrationFlag()
+        XCTAssertFalse(MigrationManager.migrationFailed)
+    }
+}

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/Models/ExerciseModelTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/Models/ExerciseModelTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+@testable import PRLiftsCore
+import PRLiftsCoreTestSupport
+import SwiftData
+import XCTest
+
+@MainActor
+final class ExerciseModelTests: XCTestCase {
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestContainerFactory.make()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        context = nil
+        container = nil
+    }
+
+    func testBasicPersistence() throws {
+        let exercise = Exercise.stub()
+        context.insert(exercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Exercise>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.name, "Bench Press")
+        XCTAssertEqual(result.category, .strength)
+        XCTAssertEqual(result.muscleGroup, .midChest)
+        XCTAssertEqual(result.equipment, .barbell)
+        XCTAssertFalse(result.isCustom)
+    }
+
+    func testSecondaryMuscleGroupsArray() throws {
+        let exercise = Exercise.stub(secondaryMuscleGroups: [.shoulders, .triceps, .biceps])
+        context.insert(exercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Exercise>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.secondaryMuscleGroups.count, 3)
+        XCTAssertTrue(result.secondaryMuscleGroups.contains(.shoulders))
+        XCTAssertTrue(result.secondaryMuscleGroups.contains(.triceps))
+        XCTAssertTrue(result.secondaryMuscleGroups.contains(.biceps))
+    }
+
+    func testEmptySecondaryMuscleGroups() throws {
+        let exercise = Exercise.stub(secondaryMuscleGroups: [])
+        context.insert(exercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Exercise>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertTrue(result.secondaryMuscleGroups.isEmpty)
+    }
+
+    func testOptionalFields() throws {
+        let exercise = Exercise(
+            name: "Pull-up",
+            category: .strength,
+            muscleGroup: .upperBack,
+            equipment: .bodyweight,
+            instructions: "Hang from bar and pull up",
+            demoURL: "https://example.com/pullup.gif"
+        )
+        context.insert(exercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Exercise>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.instructions, "Hang from bar and pull up")
+        XCTAssertEqual(result.demoURL, "https://example.com/pullup.gif")
+    }
+
+    func testNilOptionalFields() throws {
+        let exercise = Exercise.stub()
+        context.insert(exercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Exercise>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertNil(result.instructions)
+        XCTAssertNil(result.demoURL)
+        XCTAssertNil(result.createdBy)
+    }
+
+    func testCustomExercise() throws {
+        let creatorID = UUID()
+        let exercise = Exercise.stub(isCustom: true)
+        exercise.createdBy = creatorID
+        context.insert(exercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Exercise>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertTrue(result.isCustom)
+        XCTAssertEqual(result.createdBy, creatorID)
+    }
+
+    func testAllCategoriesAreValid() {
+        for category in ExerciseCategory.allCases {
+            let exercise = Exercise(
+                name: "Test \(category.rawValue)",
+                category: category,
+                muscleGroup: .abs,
+                equipment: .bodyweight
+            )
+            XCTAssertEqual(exercise.category, category)
+        }
+    }
+
+    func testAllEquipmentTypesAreValid() {
+        for equipment in ExerciseEquipment.allCases {
+            let exercise = Exercise(
+                name: "Test \(equipment.rawValue)",
+                category: .strength,
+                muscleGroup: .abs,
+                equipment: equipment
+            )
+            XCTAssertEqual(exercise.equipment, equipment)
+        }
+    }
+
+    func testAllMuscleGroupsAreValid() {
+        for group in MuscleGroup.allCases {
+            let exercise = Exercise(
+                name: "Test \(group.rawValue)",
+                category: .strength,
+                muscleGroup: group,
+                equipment: .bodyweight
+            )
+            XCTAssertEqual(exercise.muscleGroup, group)
+        }
+    }
+}

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/Models/JobModelTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/Models/JobModelTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+@testable import PRLiftsCore
+import PRLiftsCoreTestSupport
+import SwiftData
+import XCTest
+
+@MainActor
+final class JobModelTests: XCTestCase {
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestContainerFactory.make()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        context = nil
+        container = nil
+    }
+
+    func testDefaultStatus() throws {
+        let job = Job.stub()
+        context.insert(job)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Job>())
+        XCTAssertEqual(fetched.first?.status, .pending)
+    }
+
+    func testJobTypePersistence() throws {
+        for jobType in JobType.allCases {
+            let job = Job.stub(jobType: jobType)
+            context.insert(job)
+        }
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Job>())
+        XCTAssertEqual(fetched.count, JobType.allCases.count)
+    }
+
+    func testJobStatusPersistence() throws {
+        for status in JobStatus.allCases {
+            let job = Job.stub(status: status)
+            context.insert(job)
+        }
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Job>())
+        XCTAssertEqual(fetched.count, JobStatus.allCases.count)
+    }
+
+    func testExpiresAtDefaultIs5MinutesFromNow() {
+        let before = Date()
+        let job = Job.stub()
+        let after = Date()
+
+        let expectedMin = before.addingTimeInterval(300)
+        let expectedMax = after.addingTimeInterval(300)
+
+        XCTAssertGreaterThanOrEqual(job.expiresAt, expectedMin)
+        XCTAssertLessThanOrEqual(job.expiresAt, expectedMax)
+    }
+
+    func testResultPersistence() throws {
+        let job = Job.stub()
+        job.result = #"{"insight": "Great workout!"}"#
+        context.insert(job)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Job>())
+        XCTAssertEqual(fetched.first?.result, #"{"insight": "Great workout!"}"#)
+    }
+
+    func testErrorMessagePersistence() throws {
+        let job = Job.stub(status: .failed)
+        job.errorMessage = "AI provider unavailable"
+        context.insert(job)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Job>())
+        XCTAssertEqual(fetched.first?.errorMessage, "AI provider unavailable")
+    }
+
+    func testStartedAtPersistence() throws {
+        let startedAt = Date()
+        let job = Job.stub(status: .processing)
+        job.startedAt = startedAt
+        context.insert(job)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Job>())
+        let result = try XCTUnwrap(fetched.first?.startedAt)
+
+        XCTAssertEqual(result.timeIntervalSinceReferenceDate, startedAt.timeIntervalSinceReferenceDate, accuracy: 0.001)
+    }
+
+    func testCompletedAtPersistence() throws {
+        let completedAt = Date()
+        let job = Job.stub(status: .complete)
+        job.completedAt = completedAt
+        context.insert(job)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Job>())
+        let result = try XCTUnwrap(fetched.first?.completedAt)
+
+        XCTAssertEqual(
+            result.timeIntervalSinceReferenceDate,
+            completedAt.timeIntervalSinceReferenceDate,
+            accuracy: 0.001
+        )
+    }
+
+    func testNilResultAndErrorForPendingJob() throws {
+        let job = Job.stub()
+        context.insert(job)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Job>())
+        XCTAssertNil(fetched.first?.result)
+        XCTAssertNil(fetched.first?.errorMessage)
+        XCTAssertNil(fetched.first?.startedAt)
+        XCTAssertNil(fetched.first?.completedAt)
+    }
+
+    func testInsightJobType() throws {
+        let job = Job.stub(jobType: .insight)
+        context.insert(job)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Job>())
+        XCTAssertEqual(fetched.first?.jobType, .insight)
+    }
+
+    func testFutureSelfJobType() throws {
+        let job = Job.stub(jobType: .futureSelf)
+        context.insert(job)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Job>())
+        XCTAssertEqual(fetched.first?.jobType, .futureSelf)
+    }
+
+    func testExpiredStatusPersistence() throws {
+        let job = Job.stub(status: .expired)
+        context.insert(job)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Job>())
+        XCTAssertEqual(fetched.first?.status, .expired)
+    }
+}

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/Models/PersonalRecordModelTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/Models/PersonalRecordModelTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+@testable import PRLiftsCore
+import PRLiftsCoreTestSupport
+import SwiftData
+import XCTest
+
+@MainActor
+final class PersonalRecordModelTests: XCTestCase {
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestContainerFactory.make()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        context = nil
+        container = nil
+    }
+
+    func testBasicPersistence() throws {
+        let setID = UUID()
+        let pr = PersonalRecord.stub(
+            value: 315.0,
+            valueUnit: .lbs,
+            workoutSetID: setID
+        )
+        context.insert(pr)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<PersonalRecord>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.value, 315.0, accuracy: 0.001)
+        XCTAssertEqual(result.valueUnit, .lbs)
+        XCTAssertEqual(result.workoutSetID, setID)
+    }
+
+    func testRecordTypePersistence() throws {
+        for recordType in RecordType.allCases {
+            let pr = PersonalRecord(
+                weightModifier: .none,
+                recordType: recordType,
+                value: 100.0,
+                recordedAt: Date(),
+                workoutSetID: UUID()
+            )
+            context.insert(pr)
+        }
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<PersonalRecord>())
+        XCTAssertEqual(fetched.count, RecordType.allCases.count)
+    }
+
+    func testWeightModifierPersistence() throws {
+        let pr = PersonalRecord.stub(weightModifier: .assisted)
+        context.insert(pr)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<PersonalRecord>())
+        XCTAssertEqual(fetched.first?.weightModifier, .assisted)
+    }
+
+    func testPreviousValuePersistence() throws {
+        let previousDate = Date().addingTimeInterval(-86400)
+        let pr = PersonalRecord.stub(
+            value: 225.0,
+            previousValue: 205.0,
+            workoutSetID: UUID()
+        )
+        pr.previousRecordedAt = previousDate
+        context.insert(pr)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<PersonalRecord>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(try XCTUnwrap(result.previousValue), 205.0, accuracy: 0.001)
+        XCTAssertNotNil(result.previousRecordedAt)
+    }
+
+    func testNilPreviousValueAllowed() throws {
+        let pr = PersonalRecord(
+            weightModifier: .none,
+            recordType: .heaviestWeight,
+            value: 135.0,
+            recordedAt: Date(),
+            workoutSetID: UUID()
+        )
+        context.insert(pr)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<PersonalRecord>())
+        XCTAssertNil(fetched.first?.previousValue)
+        XCTAssertNil(fetched.first?.previousRecordedAt)
+    }
+
+    func testWorkoutSetIDStoredAsUUID() throws {
+        let setID = UUID()
+        let pr = PersonalRecord.stub(workoutSetID: setID)
+        context.insert(pr)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<PersonalRecord>())
+        XCTAssertEqual(fetched.first?.workoutSetID, setID)
+    }
+
+    func testValueUnitNilAllowed() throws {
+        let pr = PersonalRecord(
+            weightModifier: .none,
+            recordType: .mostReps,
+            value: 25.0,
+            valueUnit: nil,
+            recordedAt: Date(),
+            workoutSetID: UUID()
+        )
+        context.insert(pr)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<PersonalRecord>())
+        XCTAssertNil(fetched.first?.valueUnit)
+    }
+
+    func testAllValueUnits() {
+        for unit in ValueUnit.allCases {
+            let pr = PersonalRecord(
+                weightModifier: .none,
+                recordType: .longestDistance,
+                value: 100.0,
+                valueUnit: unit,
+                recordedAt: Date(),
+                workoutSetID: UUID()
+            )
+            XCTAssertEqual(pr.valueUnit, unit)
+        }
+    }
+
+    func testWeightedAndBodyweightPRsAreDistinct() throws {
+        let exerciseID = UUID()
+        let setID1 = UUID()
+        let setID2 = UUID()
+
+        let weightedPR = PersonalRecord(
+            weightModifier: .weighted,
+            recordType: .heaviestWeight,
+            value: 225.0,
+            valueUnit: .lbs,
+            recordedAt: Date(),
+            workoutSetID: setID1
+        )
+        let bodyweightPR = PersonalRecord(
+            weightModifier: .none,
+            recordType: .heaviestWeight,
+            value: 185.0,
+            valueUnit: .lbs,
+            recordedAt: Date(),
+            workoutSetID: setID2
+        )
+
+        context.insert(weightedPR)
+        context.insert(bodyweightPR)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<PersonalRecord>())
+        XCTAssertEqual(fetched.count, 2)
+
+        let weighted = fetched.first { $0.weightModifier == .weighted }
+        let bodyweight = fetched.first { $0.weightModifier == .none }
+
+        XCTAssertNotNil(weighted)
+        XCTAssertNotNil(bodyweight)
+        XCTAssertEqual(try XCTUnwrap(weighted).value, 225.0, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(bodyweight).value, 185.0, accuracy: 0.001)
+        _ = exerciseID  // exerciseID would be set via the exercise relationship
+    }
+}

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/Models/RelationshipTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/Models/RelationshipTests.swift
@@ -1,0 +1,351 @@
+import Foundation
+@testable import PRLiftsCore
+import PRLiftsCoreTestSupport
+import SwiftData
+import XCTest
+
+@MainActor
+final class RelationshipTests: XCTestCase {
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestContainerFactory.make()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        context = nil
+        container = nil
+    }
+
+    // MARK: - User ↔ Workout
+
+    func testUserWorkoutRelationship() throws {
+        let user = User.stub()
+        let workout = Workout.stub()
+        context.insert(user)
+        context.insert(workout)
+        user.workouts.append(workout)
+        try context.save()
+
+        let fetchedUsers = try context.fetch(FetchDescriptor<User>())
+        let result = try XCTUnwrap(fetchedUsers.first)
+
+        XCTAssertEqual(result.workouts.count, 1)
+        XCTAssertEqual(result.workouts.first?.name, "Morning Session")
+    }
+
+    func testUserInverseOnWorkout() throws {
+        let user = User.stub()
+        let workout = Workout.stub()
+        context.insert(user)
+        context.insert(workout)
+        user.workouts.append(workout)
+        try context.save()
+
+        let fetchedWorkouts = try context.fetch(FetchDescriptor<Workout>())
+        XCTAssertNotNil(fetchedWorkouts.first?.user)
+    }
+
+    func testUserCascadeDeletesWorkouts() throws {
+        let user = User.stub()
+        let workout = Workout.stub()
+        context.insert(user)
+        context.insert(workout)
+        user.workouts.append(workout)
+        try context.save()
+
+        context.delete(user)
+        try context.save()
+
+        let workouts = try context.fetch(FetchDescriptor<Workout>())
+        XCTAssertTrue(workouts.isEmpty)
+    }
+
+    func testUserCanHaveMultipleWorkouts() throws {
+        let user = User.stub()
+        let workout1 = Workout.stub(id: UUID(), name: "Monday Push")
+        let workout2 = Workout.stub(id: UUID(), name: "Tuesday Pull")
+        let workout3 = Workout.stub(id: UUID(), name: "Thursday Legs")
+
+        context.insert(user)
+        context.insert(workout1)
+        context.insert(workout2)
+        context.insert(workout3)
+        user.workouts.append(contentsOf: [workout1, workout2, workout3])
+        try context.save()
+
+        let fetchedUsers = try context.fetch(FetchDescriptor<User>())
+        XCTAssertEqual(fetchedUsers.first?.workouts.count, 3)
+    }
+
+    // MARK: - Workout ↔ WorkoutExercise
+
+    func testWorkoutExerciseRelationship() throws {
+        let user = User.stub()
+        let workout = Workout.stub()
+        let exercise = Exercise.stub()
+        let workoutExercise = WorkoutExercise.stub(orderIndex: 0)
+
+        context.insert(user)
+        context.insert(workout)
+        context.insert(exercise)
+        context.insert(workoutExercise)
+
+        user.workouts.append(workout)
+        workoutExercise.exercise = exercise
+        workout.exercises.append(workoutExercise)
+        try context.save()
+
+        let fetchedWorkouts = try context.fetch(FetchDescriptor<Workout>())
+        XCTAssertEqual(fetchedWorkouts.first?.exercises.count, 1)
+        XCTAssertEqual(fetchedWorkouts.first?.exercises.first?.orderIndex, 0)
+    }
+
+    func testWorkoutCascadeDeletesWorkoutExercises() throws {
+        let user = User.stub()
+        let workout = Workout.stub()
+        let workoutExercise = WorkoutExercise.stub()
+
+        context.insert(user)
+        context.insert(workout)
+        context.insert(workoutExercise)
+        user.workouts.append(workout)
+        workout.exercises.append(workoutExercise)
+        try context.save()
+
+        context.delete(workout)
+        try context.save()
+
+        let workoutExercises = try context.fetch(FetchDescriptor<WorkoutExercise>())
+        XCTAssertTrue(workoutExercises.isEmpty)
+    }
+
+    // MARK: - WorkoutExercise ↔ WorkoutSet
+
+    func testWorkoutSetRelationship() throws {
+        let workoutExercise = WorkoutExercise.stub()
+        let set1 = WorkoutSet.stub(setNumber: 1, weight: 135.0, reps: 10)
+        let set2 = WorkoutSet.stub(setNumber: 2, weight: 145.0, reps: 8)
+
+        context.insert(workoutExercise)
+        context.insert(set1)
+        context.insert(set2)
+        workoutExercise.sets.append(contentsOf: [set1, set2])
+        try context.save()
+
+        let fetchedExercises = try context.fetch(FetchDescriptor<WorkoutExercise>())
+        XCTAssertEqual(fetchedExercises.first?.sets.count, 2)
+    }
+
+    func testWorkoutExerciseCascadeDeletesSets() throws {
+        let workoutExercise = WorkoutExercise.stub()
+        let set = WorkoutSet.stub(setNumber: 1, reps: 10)
+
+        context.insert(workoutExercise)
+        context.insert(set)
+        workoutExercise.sets.append(set)
+        try context.save()
+
+        context.delete(workoutExercise)
+        try context.save()
+
+        let sets = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertTrue(sets.isEmpty)
+    }
+
+    func testWorkoutSetInverseOnWorkoutExercise() throws {
+        let workoutExercise = WorkoutExercise.stub()
+        let workoutSet = WorkoutSet.stub(setNumber: 1, reps: 12)
+
+        context.insert(workoutExercise)
+        context.insert(workoutSet)
+        workoutExercise.sets.append(workoutSet)
+        try context.save()
+
+        let fetchedSets = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertNotNil(fetchedSets.first?.workoutExercise)
+    }
+
+    // MARK: - User ↔ PersonalRecord
+
+    func testUserPersonalRecordRelationship() throws {
+        let user = User.stub()
+        let pr = PersonalRecord.stub(value: 315.0, valueUnit: .lbs, workoutSetID: UUID())
+
+        context.insert(user)
+        context.insert(pr)
+        user.personalRecords.append(pr)
+        try context.save()
+
+        let fetchedUsers = try context.fetch(FetchDescriptor<User>())
+        XCTAssertEqual(fetchedUsers.first?.personalRecords.count, 1)
+        XCTAssertEqual(try XCTUnwrap(fetchedUsers.first?.personalRecords.first?.value), 315.0, accuracy: 0.001)
+    }
+
+    func testUserCascadeDeletesPersonalRecords() throws {
+        let user = User.stub()
+        let pr = PersonalRecord.stub(workoutSetID: UUID())
+
+        context.insert(user)
+        context.insert(pr)
+        user.personalRecords.append(pr)
+        try context.save()
+
+        context.delete(user)
+        try context.save()
+
+        let records = try context.fetch(FetchDescriptor<PersonalRecord>())
+        XCTAssertTrue(records.isEmpty)
+    }
+
+    // MARK: - User ↔ Job
+
+    func testUserJobRelationship() throws {
+        let user = User.stub()
+        let job = Job.stub(jobType: .insight)
+
+        context.insert(user)
+        context.insert(job)
+        user.jobs.append(job)
+        try context.save()
+
+        let fetchedUsers = try context.fetch(FetchDescriptor<User>())
+        XCTAssertEqual(fetchedUsers.first?.jobs.count, 1)
+        XCTAssertEqual(fetchedUsers.first?.jobs.first?.jobType, .insight)
+    }
+
+    func testUserCascadeDeletesJobs() throws {
+        let user = User.stub()
+        let job = Job.stub()
+
+        context.insert(user)
+        context.insert(job)
+        user.jobs.append(job)
+        try context.save()
+
+        context.delete(user)
+        try context.save()
+
+        let jobs = try context.fetch(FetchDescriptor<Job>())
+        XCTAssertTrue(jobs.isEmpty)
+    }
+
+    // MARK: - User ↔ SyncEventLog
+
+    func testUserSyncEventLogRelationship() throws {
+        let user = User.stub()
+        let log = SyncEventLog.stub(eventType: .writeAttempt, entityType: .workout)
+
+        context.insert(user)
+        context.insert(log)
+        user.syncEventLogs.append(log)
+        try context.save()
+
+        let fetchedUsers = try context.fetch(FetchDescriptor<User>())
+        XCTAssertEqual(fetchedUsers.first?.syncEventLogs.count, 1)
+    }
+
+    func testUserCascadeDeletesSyncEventLogs() throws {
+        let user = User.stub()
+        let log = SyncEventLog.stub()
+
+        context.insert(user)
+        context.insert(log)
+        user.syncEventLogs.append(log)
+        try context.save()
+
+        context.delete(user)
+        try context.save()
+
+        let logs = try context.fetch(FetchDescriptor<SyncEventLog>())
+        XCTAssertTrue(logs.isEmpty)
+    }
+
+    // MARK: - Exercise ↔ WorkoutExercise
+
+    func testExerciseWorkoutExerciseRelationship() throws {
+        let exercise = Exercise.stub()
+        let workoutExercise = WorkoutExercise.stub()
+
+        context.insert(exercise)
+        context.insert(workoutExercise)
+        workoutExercise.exercise = exercise
+        try context.save()
+
+        let fetchedExercise = try context.fetch(FetchDescriptor<Exercise>())
+        XCTAssertEqual(fetchedExercise.first?.workoutExercises.count, 1)
+    }
+
+    // MARK: - Exercise ↔ PersonalRecord
+
+    func testExercisePersonalRecordRelationship() throws {
+        let exercise = Exercise.stub()
+        let pr = PersonalRecord.stub(workoutSetID: UUID())
+
+        context.insert(exercise)
+        context.insert(pr)
+        pr.exercise = exercise
+        try context.save()
+
+        let fetchedExercise = try context.fetch(FetchDescriptor<Exercise>())
+        XCTAssertEqual(fetchedExercise.first?.personalRecords.count, 1)
+    }
+
+    // MARK: - Full chain
+
+    func testFullWorkoutChain() throws {
+        let user = User.stub()
+        let exercise = Exercise.stub()
+        let workout = Workout.stub()
+        let workoutExercise = WorkoutExercise.stub(orderIndex: 0)
+        let set1 = WorkoutSet.stub(setNumber: 1, weight: 225.0, reps: 5)
+        let set2 = WorkoutSet.stub(setNumber: 2, weight: 235.0, reps: 3)
+
+        context.insert(user)
+        context.insert(exercise)
+        context.insert(workout)
+        context.insert(workoutExercise)
+        context.insert(set1)
+        context.insert(set2)
+
+        user.workouts.append(workout)
+        workoutExercise.exercise = exercise
+        workout.exercises.append(workoutExercise)
+        workoutExercise.sets.append(contentsOf: [set1, set2])
+        try context.save()
+
+        let fetchedUsers = try context.fetch(FetchDescriptor<User>())
+        let fetchedUser = try XCTUnwrap(fetchedUsers.first)
+
+        XCTAssertEqual(fetchedUser.workouts.count, 1)
+        XCTAssertEqual(fetchedUser.workouts.first?.exercises.count, 1)
+        XCTAssertEqual(fetchedUser.workouts.first?.exercises.first?.sets.count, 2)
+        XCTAssertEqual(fetchedUser.workouts.first?.exercises.first?.exercise?.name, "Bench Press")
+    }
+
+    func testCascadeFromUserDeletesEntireChain() throws {
+        let user = User.stub()
+        let workout = Workout.stub()
+        let workoutExercise = WorkoutExercise.stub()
+        let workoutSet = WorkoutSet.stub(setNumber: 1, reps: 10)
+
+        context.insert(user)
+        context.insert(workout)
+        context.insert(workoutExercise)
+        context.insert(workoutSet)
+
+        user.workouts.append(workout)
+        workout.exercises.append(workoutExercise)
+        workoutExercise.sets.append(workoutSet)
+        try context.save()
+
+        context.delete(user)
+        try context.save()
+
+        XCTAssertTrue(try context.fetch(FetchDescriptor<Workout>()).isEmpty)
+        XCTAssertTrue(try context.fetch(FetchDescriptor<WorkoutExercise>()).isEmpty)
+        XCTAssertTrue(try context.fetch(FetchDescriptor<WorkoutSet>()).isEmpty)
+    }
+}

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/Models/SyncEventLogModelTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/Models/SyncEventLogModelTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+@testable import PRLiftsCore
+import PRLiftsCoreTestSupport
+import SwiftData
+import XCTest
+
+@MainActor
+final class SyncEventLogModelTests: XCTestCase {
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestContainerFactory.make()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        context = nil
+        container = nil
+    }
+
+    func testBasicPersistence() throws {
+        let entityID = UUID()
+        let log = SyncEventLog.stub(
+            eventType: .syncSuccess,
+            entityType: .workout,
+            entityID: entityID
+        )
+        context.insert(log)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SyncEventLog>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.eventType, .syncSuccess)
+        XCTAssertEqual(result.entityType, .workout)
+        XCTAssertEqual(result.entityID, entityID)
+    }
+
+    func testAllEventTypes() throws {
+        for eventType in SyncEventType.allCases {
+            let log = SyncEventLog.stub(eventType: eventType, entityID: UUID())
+            context.insert(log)
+        }
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SyncEventLog>())
+        XCTAssertEqual(fetched.count, SyncEventType.allCases.count)
+    }
+
+    func testAllEntityTypes() throws {
+        for entityType in SyncEntityType.allCases {
+            let log = SyncEventLog.stub(entityType: entityType, entityID: UUID())
+            context.insert(log)
+        }
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SyncEventLog>())
+        XCTAssertEqual(fetched.count, SyncEntityType.allCases.count)
+    }
+
+    func testDetailPersistence() throws {
+        let log = SyncEventLog.stub(detail: "Network timeout after 30s")
+        context.insert(log)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SyncEventLog>())
+        XCTAssertEqual(fetched.first?.detail, "Network timeout after 30s")
+    }
+
+    func testNilDetailAllowed() throws {
+        let log = SyncEventLog.stub(detail: nil)
+        context.insert(log)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SyncEventLog>())
+        XCTAssertNil(fetched.first?.detail)
+    }
+
+    func testUploadedAtNilByDefault() throws {
+        let log = SyncEventLog.stub()
+        context.insert(log)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SyncEventLog>())
+        XCTAssertNil(fetched.first?.uploadedAt)
+    }
+
+    func testUploadedAtPersistence() throws {
+        let uploadTime = Date()
+        let log = SyncEventLog.stub()
+        log.uploadedAt = uploadTime
+        context.insert(log)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SyncEventLog>())
+        let result = try XCTUnwrap(fetched.first?.uploadedAt)
+
+        XCTAssertEqual(
+            result.timeIntervalSinceReferenceDate,
+            uploadTime.timeIntervalSinceReferenceDate,
+            accuracy: 0.001
+        )
+    }
+
+    func testOccurredAtPersistence() throws {
+        let occurredAt = Date().addingTimeInterval(-3600)
+        let log = SyncEventLog.stub(occurredAt: occurredAt)
+        context.insert(log)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SyncEventLog>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(
+            result.occurredAt.timeIntervalSinceReferenceDate,
+            occurredAt.timeIntervalSinceReferenceDate,
+            accuracy: 0.001
+        )
+    }
+
+    func testSyncFailureWithDetail() throws {
+        let log = SyncEventLog.stub(
+            eventType: .syncFailure,
+            entityType: .workoutSet,
+            detail: "Connection refused"
+        )
+        context.insert(log)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SyncEventLog>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.eventType, .syncFailure)
+        XCTAssertEqual(result.detail, "Connection refused")
+    }
+
+    func testConflictResolvedEvent() throws {
+        let log = SyncEventLog.stub(
+            eventType: .conflictResolved,
+            entityType: .personalRecord,
+            detail: "Server timestamp wins"
+        )
+        context.insert(log)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SyncEventLog>())
+        XCTAssertEqual(fetched.first?.eventType, .conflictResolved)
+    }
+
+    func testEntityIDPreserved() throws {
+        let entityID = UUID()
+        let log = SyncEventLog.stub(entityID: entityID)
+        context.insert(log)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SyncEventLog>())
+        XCTAssertEqual(fetched.first?.entityID, entityID)
+    }
+}

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/Models/UserModelTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/Models/UserModelTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+@testable import PRLiftsCore
+import PRLiftsCoreTestSupport
+import SwiftData
+import XCTest
+
+@MainActor
+final class UserModelTests: XCTestCase {
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestContainerFactory.make()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        context = nil
+        container = nil
+    }
+
+    func testDefaultValues() throws {
+        let user = User.stub()
+        context.insert(user)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<User>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.unitPreference, .lbs)
+        XCTAssertEqual(result.measurementUnit, .cm)
+        XCTAssertEqual(result.gender, .na)
+        XCTAssertEqual(result.betaTier, .none)
+        XCTAssertNil(result.goal)
+        XCTAssertNil(result.phase2CompletedAt)
+        XCTAssertNil(result.dateOfBirth)
+    }
+
+    func testPersistsEmail() throws {
+        let user = User.stub(email: "athlete@example.com", displayName: "Jordan")
+        context.insert(user)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<User>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.email, "athlete@example.com")
+        XCTAssertEqual(result.displayName, "Jordan")
+    }
+
+    func testNullableEmailAllowed() throws {
+        let user = User.stub(email: nil, displayName: nil)
+        context.insert(user)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<User>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertNil(result.email)
+        XCTAssertNil(result.displayName)
+    }
+
+    func testGoalEnum() throws {
+        let user = User.stub(goal: .buildMuscle)
+        context.insert(user)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<User>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.goal, .buildMuscle)
+    }
+
+    func testBetaTierEnum() throws {
+        let user = User.stub(betaTier: .fullAccess)
+        context.insert(user)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<User>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.betaTier, .fullAccess)
+    }
+
+    func testUnitPreferenceEnum() throws {
+        let user = User.stub(unitPreference: .kg)
+        context.insert(user)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<User>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.unitPreference, .kg)
+    }
+
+    func testPhase2CompletedAtStoredAsUTC() throws {
+        let now = Date()
+        let user = User(phase2CompletedAt: now)
+        context.insert(user)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<User>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(
+            result.phase2CompletedAt?.timeIntervalSinceReferenceDate ?? 0,
+            now.timeIntervalSinceReferenceDate,
+            accuracy: 0.001
+        )
+    }
+
+    func testIDIsPreservedAfterSave() throws {
+        let id = UUID()
+        let user = User.stub(id: id)
+        context.insert(user)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<User>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.id, id)
+    }
+
+    func testEmptyRelationshipsOnCreation() throws {
+        let user = User.stub()
+        context.insert(user)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<User>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertTrue(result.workouts.isEmpty)
+        XCTAssertTrue(result.personalRecords.isEmpty)
+        XCTAssertTrue(result.jobs.isEmpty)
+        XCTAssertTrue(result.syncEventLogs.isEmpty)
+    }
+
+    func testMultipleUsersCanExist() throws {
+        context.insert(User.stub(id: UUID(), email: "a@example.com"))
+        context.insert(User.stub(id: UUID(), email: "b@example.com"))
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<User>())
+        XCTAssertEqual(fetched.count, 2)
+    }
+}

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/Models/WorkoutExerciseModelTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/Models/WorkoutExerciseModelTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+@testable import PRLiftsCore
+import PRLiftsCoreTestSupport
+import SwiftData
+import XCTest
+
+@MainActor
+final class WorkoutExerciseModelTests: XCTestCase {
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestContainerFactory.make()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        context = nil
+        container = nil
+    }
+
+    func testOrderIndexPersistence() throws {
+        let workoutExercise = WorkoutExercise.stub(orderIndex: 3)
+        context.insert(workoutExercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutExercise>())
+        XCTAssertEqual(fetched.first?.orderIndex, 3)
+    }
+
+    func testOptionalNotesPersistence() throws {
+        let workoutExercise = WorkoutExercise(orderIndex: 0, notes: "Focus on form")
+        context.insert(workoutExercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutExercise>())
+        XCTAssertEqual(fetched.first?.notes, "Focus on form")
+    }
+
+    func testNilNotesAllowed() throws {
+        let workoutExercise = WorkoutExercise.stub()
+        context.insert(workoutExercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutExercise>())
+        XCTAssertNil(fetched.first?.notes)
+    }
+
+    func testRestSecondsPersistence() throws {
+        let workoutExercise = WorkoutExercise.stub(restSeconds: 120)
+        context.insert(workoutExercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutExercise>())
+        XCTAssertEqual(fetched.first?.restSeconds, 120)
+    }
+
+    func testNilRestSecondsAllowed() throws {
+        let workoutExercise = WorkoutExercise(orderIndex: 0, restSeconds: nil)
+        context.insert(workoutExercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutExercise>())
+        XCTAssertNil(fetched.first?.restSeconds)
+    }
+
+    func testIDPreserved() throws {
+        let id = UUID()
+        let workoutExercise = WorkoutExercise.stub(id: id)
+        context.insert(workoutExercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutExercise>())
+        XCTAssertEqual(fetched.first?.id, id)
+    }
+
+    func testEmptySetsOnCreation() throws {
+        let workoutExercise = WorkoutExercise.stub()
+        context.insert(workoutExercise)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutExercise>())
+        XCTAssertTrue(fetched.first?.sets.isEmpty ?? false)
+    }
+
+    func testTimestampsDefault() throws {
+        let before = Date()
+        let workoutExercise = WorkoutExercise.stub()
+        let after = Date()
+
+        XCTAssertGreaterThanOrEqual(workoutExercise.createdAt, before)
+        XCTAssertLessThanOrEqual(workoutExercise.createdAt, after)
+        XCTAssertGreaterThanOrEqual(workoutExercise.updatedAt, before)
+        XCTAssertLessThanOrEqual(workoutExercise.updatedAt, after)
+    }
+}

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/Models/WorkoutModelTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/Models/WorkoutModelTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+@testable import PRLiftsCore
+import PRLiftsCoreTestSupport
+import SwiftData
+import XCTest
+
+@MainActor
+final class WorkoutModelTests: XCTestCase {
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestContainerFactory.make()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        context = nil
+        container = nil
+    }
+
+    func testDefaultStatus() throws {
+        let workout = Workout.stub()
+        context.insert(workout)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Workout>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.status, .inProgress)
+    }
+
+    func testStatusTransitions() throws {
+        let workout = Workout.stub(status: .completed)
+        context.insert(workout)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Workout>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.status, .completed)
+    }
+
+    func testPartialCompletionStatus() throws {
+        let workout = Workout.stub(status: .partialCompletion)
+        context.insert(workout)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Workout>())
+        XCTAssertEqual(fetched.first?.status, .partialCompletion)
+    }
+
+    func testWorkoutTypePersistence() throws {
+        let workout = Workout.stub(type: .planned)
+        context.insert(workout)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Workout>())
+        XCTAssertEqual(fetched.first?.type, .planned)
+    }
+
+    func testWorkoutFormatPersistence() throws {
+        let workout = Workout.stub(format: .cardio)
+        context.insert(workout)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Workout>())
+        XCTAssertEqual(fetched.first?.format, .cardio)
+    }
+
+    func testOptionalLocationPersists() throws {
+        let workout = Workout.stub(location: .outdoor)
+        context.insert(workout)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Workout>())
+        XCTAssertEqual(fetched.first?.location, .outdoor)
+    }
+
+    func testNilLocationAllowed() throws {
+        let workout = Workout(type: .adHoc, format: .weightlifting, location: nil)
+        context.insert(workout)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Workout>())
+        XCTAssertNil(fetched.first?.location)
+    }
+
+    func testRatingPersistence() throws {
+        let workout = Workout(type: .adHoc, format: .weightlifting)
+        workout.rating = 4
+        context.insert(workout)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Workout>())
+        XCTAssertEqual(fetched.first?.rating, 4)
+    }
+
+    func testDurationSecondsPersistence() throws {
+        let workout = Workout(type: .adHoc, format: .mixed)
+        workout.durationSeconds = 3600
+        context.insert(workout)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Workout>())
+        XCTAssertEqual(fetched.first?.durationSeconds, 3600)
+    }
+
+    func testServerReceivedAtDefaults() throws {
+        let before = Date()
+        let workout = Workout.stub()
+        let after = Date()
+
+        XCTAssertGreaterThanOrEqual(workout.serverReceivedAt, before)
+        XCTAssertLessThanOrEqual(workout.serverReceivedAt, after)
+    }
+
+    func testCompletedAtPersistence() throws {
+        let completedAt = Date()
+        let workout = Workout(type: .adHoc, format: .weightlifting, completedAt: completedAt)
+        context.insert(workout)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Workout>())
+        let result = try XCTUnwrap(fetched.first?.completedAt)
+
+        XCTAssertEqual(
+            result.timeIntervalSinceReferenceDate,
+            completedAt.timeIntervalSinceReferenceDate,
+            accuracy: 0.001
+        )
+    }
+
+    func testEmptyExercisesOnCreation() throws {
+        let workout = Workout.stub()
+        context.insert(workout)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Workout>())
+        XCTAssertTrue(fetched.first?.exercises.isEmpty ?? false)
+    }
+}

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/Models/WorkoutSetModelTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/Models/WorkoutSetModelTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+@testable import PRLiftsCore
+import PRLiftsCoreTestSupport
+import SwiftData
+import XCTest
+
+@MainActor
+final class WorkoutSetModelTests: XCTestCase {
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestContainerFactory.make()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        context = nil
+        container = nil
+    }
+
+    func testDefaultValues() throws {
+        let workoutSet = WorkoutSet(setNumber: 1, reps: 10)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.setType, .normal)
+        XCTAssertEqual(result.weightModifier, .none)
+        XCTAssertFalse(result.isCompleted)
+    }
+
+    func testWeightAndRepsPersistence() throws {
+        let workoutSet = WorkoutSet.stub(weight: 135.0, weightUnit: .lbs, reps: 8)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(try XCTUnwrap(result.weight), 135.0, accuracy: 0.001)
+        XCTAssertEqual(result.weightUnit, .lbs)
+        XCTAssertEqual(result.reps, 8)
+    }
+
+    func testKilogramWeightUnit() throws {
+        let workoutSet = WorkoutSet.stub(weight: 60.0, weightUnit: .kg, reps: 10)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertEqual(fetched.first?.weightUnit, .kg)
+    }
+
+    func testSetTypePersistence() throws {
+        let workoutSet = WorkoutSet.stub(setType: .warmup)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertEqual(fetched.first?.setType, .warmup)
+    }
+
+    func testWeightModifierAssisted() throws {
+        let workoutSet = WorkoutSet(
+            setNumber: 1,
+            weightModifier: .assisted,
+            modifierValue: 45.0,
+            modifierUnit: .lbs,
+            reps: 10
+        )
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.weightModifier, .assisted)
+        XCTAssertEqual(try XCTUnwrap(result.modifierValue), 45.0, accuracy: 0.001)
+        XCTAssertEqual(result.modifierUnit, .lbs)
+    }
+
+    func testWeightModifierWeighted() throws {
+        let workoutSet = WorkoutSet(
+            setNumber: 1,
+            weightModifier: .weighted,
+            modifierValue: 25.0,
+            modifierUnit: .lbs,
+            reps: 12
+        )
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertEqual(fetched.first?.weightModifier, .weighted)
+    }
+
+    func testDurationSecondsPersistence() throws {
+        let workoutSet = WorkoutSet(setNumber: 1, durationSeconds: 60)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertEqual(fetched.first?.durationSeconds, 60)
+    }
+
+    func testDistanceMetersPersistence() throws {
+        let workoutSet = WorkoutSet(setNumber: 1, distanceMeters: 400.0)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertEqual(try XCTUnwrap(fetched.first?.distanceMeters), 400.0, accuracy: 0.001)
+    }
+
+    func testRPEPersistence() throws {
+        let workoutSet = WorkoutSet(setNumber: 1, weight: 200.0, reps: 5, rpe: 9)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertEqual(fetched.first?.rpe, 9)
+    }
+
+    func testCaloriesPersistence() throws {
+        let workoutSet = WorkoutSet(setNumber: 1, durationSeconds: 1800, calories: 320)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertEqual(fetched.first?.calories, 320)
+    }
+
+    func testIsCompletedPersistence() throws {
+        let workoutSet = WorkoutSet.stub(isCompleted: true)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertTrue(fetched.first?.isCompleted ?? false)
+    }
+
+    func testPRSetTypePersistence() throws {
+        let workoutSet = WorkoutSet.stub(setType: .pr)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertEqual(fetched.first?.setType, .pr)
+    }
+
+    func testSetNumberPersistence() throws {
+        let workoutSet = WorkoutSet.stub(setNumber: 5)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertEqual(fetched.first?.setNumber, 5)
+    }
+
+    func testNilWeightAllowed() throws {
+        let workoutSet = WorkoutSet(setNumber: 1, durationSeconds: 30)
+        context.insert(workoutSet)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<WorkoutSet>())
+        XCTAssertNil(fetched.first?.weight)
+        XCTAssertNil(fetched.first?.weightUnit)
+    }
+}

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/PRLiftsCoreTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/PRLiftsCoreTests.swift
@@ -1,12 +1,3 @@
-import XCTest
-@testable import PRLiftsCore
-
-final class PRLiftsCoreTests: XCTestCase {
-    func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
-
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
-    }
-}
+// Tests are organized in:
+//   Models/        — per-entity model tests + RelationshipTests
+//   Migration/     — MigrationManagerTests


### PR DESCRIPTION
## Summary

- Adds SwiftData `@Model` classes for all 8 V1 entities: `User`, `Exercise`, `Workout`, `WorkoutExercise`, `WorkoutSet`, `PersonalRecord`, `Job`, `SyncEventLog`
- All models match the SCHEMA.md column definitions; all timestamps stored as UTC `Date`
- All relationships defined with correct delete rules (cascade on owner-side, nullify on shared entities)
- `MigrationManager` writes a UserDefaults flag before migration and clears it on success — app launch can detect an interrupted migration and show a recovery flow
- `PRLiftsSchema.makeContainer(inMemory:)` provides a single entry point for creating the SwiftData stack
- `PRLiftsCoreTestSupport` target exposes `stub()` factories and `TestContainerFactory.make()` for tests
- 114 unit tests covering: per-entity field persistence, all enum cases, all relationships, cascade deletes, and migration flag behaviour

## Test plan

- [x] `swift test` — 114/114 passing, 0 failures
- [x] SwiftLint clean (root `.swiftlint.yml` config)
- [x] All 8 Definition of Done items satisfied per issue #41

## Definition of Done checklist

- [x] SwiftData models for all 8 V1 entities
- [x] All models match SCHEMA.md column definitions
- [x] All relationships correctly defined
- [x] Static `.stub()` factory for every model
- [x] Migration safety flag implemented
- [x] Unit tests for all models and relationships
- [x] SwiftLint clean
- [x] PR opened with description

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)