### PR TITLE
Add rate limiting middleware — Upstash Redis

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -37,6 +37,12 @@ class Settings:
         self.ai_providers_mocked: bool = (
             os.environ.get("AI_PROVIDERS_MOCKED", "false").lower() == "true"
         )
+        # Redis — Upstash uses rediss:// in staging/production. Empty = fail open.
+        self.redis_url: str = os.environ.get("REDIS_URL", "")
+        # Rate limits — requests per 60-second window. See docs/ENV_CONFIG.md.
+        self.rate_limit_general: int = int(os.environ.get("RATE_LIMIT_GENERAL", "100"))
+        self.rate_limit_ai: int = int(os.environ.get("RATE_LIMIT_AI", "10"))
+        self.rate_limit_auth: int = int(os.environ.get("RATE_LIMIT_AUTH", "5"))
 
 
 @lru_cache(maxsize=1)

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -1,0 +1,146 @@
+"""
+rate_limit.py
+PRLifts Backend
+
+Rate limiting middleware using Redis fixed-window counters (60-second windows).
+
+Three tiers, per docs/ARCHITECTURE.md — Security Standards:
+  AI endpoints (/v1/jobs):       10 requests/min per authenticated user
+  Auth endpoints (/v1/auth):      5 requests/min per IP
+  General endpoints (/v1/...):  100 requests/min per authenticated user
+
+Rate limit key format: {identifier}:{category}:{window_minute}
+  where window_minute = int(time.time()) // 60
+
+Fails open when Redis is unavailable — requests are never blocked due to a
+Redis failure. An ERROR log is written so on-call can investigate.
+See docs/ARCHITECTURE.md — Rate Limiting, docs/ENV_CONFIG.md — RATE_LIMIT_*.
+"""
+
+import base64
+import json
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from app.config import get_settings
+from app.schemas import ErrorResponse
+
+logger = logging.getLogger(__name__)
+
+_AI_PREFIXES = ("/v1/jobs",)
+_AUTH_PREFIXES = ("/v1/auth",)
+_SKIP_PATHS = ("/health",)
+
+_RATE_LIMIT_MESSAGE = "Too many requests. Please try again later."
+
+
+def _classify(path: str) -> str:
+    """Returns the rate limit tier for a request path."""
+    if path in _SKIP_PATHS or path.startswith("/health/"):
+        return "skip"
+    for prefix in _AI_PREFIXES:
+        if path.startswith(prefix):
+            return "ai"
+    for prefix in _AUTH_PREFIXES:
+        if path.startswith(prefix):
+            return "auth"
+    return "general"
+
+
+def _extract_sub(authorization: str) -> str | None:
+    """
+    Extracts the JWT sub claim without signature verification.
+
+    Used only for rate-limit keying — the auth dependency performs full
+    JWT validation later in the request cycle. A manipulated sub here
+    can only affect the caller's own rate-limit bucket.
+    """
+    if not authorization.startswith("Bearer "):
+        return None
+    token = authorization.removeprefix("Bearer ")
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        padded = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded))
+        sub = payload.get("sub")
+        return sub if isinstance(sub, str) and sub else None
+    except Exception:
+        return None
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """
+    Enforces per-user (or per-IP for auth routes) request rate limits.
+
+    Reads app.state.redis on each dispatch — set during the app lifespan.
+    If app.state.redis is None the middleware is a no-op (fail open).
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        category = _classify(request.url.path)
+        if category == "skip":
+            return await call_next(request)
+
+        redis_client: Any | None = getattr(request.app.state, "redis", None)
+        if redis_client is None:
+            return await call_next(request)
+
+        settings = get_settings()
+
+        if category == "auth":
+            identifier = (
+                request.client.host if request.client else "unknown"
+            ) or "unknown"
+            limit = settings.rate_limit_auth
+        else:
+            sub = _extract_sub(request.headers.get("authorization", ""))
+            identifier = (
+                sub
+                or (request.client.host if request.client else "unknown")
+                or "unknown"
+            )
+            if category == "ai":
+                limit = settings.rate_limit_ai
+            else:
+                limit = settings.rate_limit_general
+
+        window = int(time.time()) // 60
+        key = f"{identifier}:{category}:{window}"
+
+        try:
+            current: int = await redis_client.incr(key)
+            if current == 1:
+                await redis_client.expire(key, 60)
+        except Exception as exc:
+            logger.error(
+                "Rate limiter Redis failure",
+                extra={"error": str(exc), "key": key},
+            )
+            return await call_next(request)
+
+        if current > limit:
+            seconds_remaining = 60 - (int(time.time()) % 60)
+            correlation_id = str(getattr(request.state, "correlation_id", ""))
+            return JSONResponse(
+                status_code=429,
+                content=ErrorResponse(
+                    error_code="rate_limit_exceeded",
+                    message=_RATE_LIMIT_MESSAGE,
+                    request_id=correlation_id,
+                ).model_dump(),
+                headers={"Retry-After": str(seconds_remaining)},
+            )
+
+        return await call_next(request)

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,7 @@ from sentry_sdk.integrations.starlette import StarletteIntegration
 from app.config import get_settings
 from app.logging_config import configure_logging
 from app.middleware.correlation_id import CorrelationIDMiddleware
+from app.middleware.rate_limit import RateLimitMiddleware
 from app.routers.health import router as health_router
 from app.routers.jobs import router as jobs_router
 from app.routers.users import router as users_router
@@ -92,6 +93,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     configure_logging(settings.log_level)
     _init_sentry(settings.sentry_dsn, settings.environment)
 
+    redis_client = None
+    if settings.redis_url:
+        from redis.asyncio import Redis
+
+        redis_client = Redis.from_url(settings.redis_url, decode_responses=True)
+    app.state.redis = redis_client
+
     scheduler.add_job(
         _cleanup_expired_jobs_noop,
         "interval",
@@ -110,6 +118,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     yield
 
     scheduler.shutdown()
+    if app.state.redis is not None:
+        await app.state.redis.aclose()
     logger.info("Application stopped")
 
 
@@ -143,6 +153,10 @@ def create_app() -> FastAPI:
         title="PRLifts API",
         lifespan=lifespan,
     )
+    # Middleware registration order: last-added runs first (outermost).
+    # CorrelationIDMiddleware must run before RateLimitMiddleware so that
+    # request.state.correlation_id is populated for the 429 error body.
+    app.add_middleware(RateLimitMiddleware)
     app.add_middleware(CorrelationIDMiddleware)
     app.add_exception_handler(HTTPException, _http_exception_handler)  # type: ignore[arg-type]
     app.include_router(health_router)

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,373 @@
+"""
+test_rate_limit.py
+PRLifts Backend Tests
+
+Tests for the rate limiting middleware.
+
+Covers:
+  - _classify: endpoint tier classification
+  - _extract_sub: JWT sub extraction without signature verification
+  - RateLimitMiddleware: 429 on limit exceeded, Retry-After header,
+    fail open on Redis unavailability, per-tier limits, IP fallback for auth routes.
+
+Redis is injected by setting app.state.redis directly after the lifespan
+has started (REDIS_URL is not set in tests, so lifespan sets it to None).
+The autouse _restore_redis fixture resets it to None after each test.
+
+See GitHub Issue #40 for acceptance criteria.
+"""
+
+import base64
+import json
+import os
+import time
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("ENVIRONMENT", "test")
+os.environ.setdefault("LOG_LEVEL", "DEBUG")
+os.environ.setdefault("APP_VERSION", "0.1.0")
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-supabase-jwt-secret-for-unit-tests")
+
+from main import app  # noqa: E402
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_fake_jwt(user_id: str) -> str:
+    """
+    Builds a minimal JWT with the given sub claim.
+
+    The signature is intentionally invalid — _extract_sub only decodes
+    the payload without verifying the signature.
+    """
+    header_bytes = b'{"alg":"HS256","typ":"JWT"}'
+    header = base64.urlsafe_b64encode(header_bytes).rstrip(b"=").decode()
+    payload_bytes = json.dumps({"sub": user_id}).encode()
+    payload = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode()
+    return f"{header}.{payload}.fakesig"
+
+
+def _make_redis_mock(count: int = 1) -> MagicMock:
+    """Returns a mock Redis client whose INCR always returns `count`."""
+    mock = MagicMock()
+    mock.incr = AsyncMock(return_value=count)
+    mock.expire = AsyncMock(return_value=True)
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def _restore_redis() -> Generator[None, None, None]:
+    """Resets app.state.redis to None after each test."""
+    yield
+    app.state.redis = None
+
+
+# ── _classify ─────────────────────────────────────────────────────────────────
+
+
+def test_classify_health_returns_skip() -> None:
+    from app.middleware.rate_limit import _classify
+
+    assert _classify("/health") == "skip"
+
+
+def test_classify_health_subpath_returns_skip() -> None:
+    from app.middleware.rate_limit import _classify
+
+    assert _classify("/health/live") == "skip"
+
+
+def test_classify_jobs_root_returns_ai() -> None:
+    from app.middleware.rate_limit import _classify
+
+    assert _classify("/v1/jobs") == "ai"
+
+
+def test_classify_jobs_with_id_returns_ai() -> None:
+    from app.middleware.rate_limit import _classify
+
+    assert _classify("/v1/jobs/abc-123") == "ai"
+
+
+def test_classify_auth_endpoint_returns_auth() -> None:
+    from app.middleware.rate_limit import _classify
+
+    assert _classify("/v1/auth/login") == "auth"
+
+
+def test_classify_users_returns_general() -> None:
+    from app.middleware.rate_limit import _classify
+
+    assert _classify("/v1/users/me") == "general"
+
+
+def test_classify_workouts_returns_general() -> None:
+    from app.middleware.rate_limit import _classify
+
+    assert _classify("/v1/workouts") == "general"
+
+
+def test_classify_workout_sets_returns_general() -> None:
+    from app.middleware.rate_limit import _classify
+
+    assert _classify("/v1/workout-sets") == "general"
+
+
+# ── _extract_sub ──────────────────────────────────────────────────────────────
+
+
+def test_extract_sub_returns_sub_from_valid_jwt() -> None:
+    from app.middleware.rate_limit import _extract_sub
+
+    token = _make_fake_jwt("user-abc-123")
+    assert _extract_sub(f"Bearer {token}") == "user-abc-123"
+
+
+def test_extract_sub_returns_none_for_missing_bearer_prefix() -> None:
+    from app.middleware.rate_limit import _extract_sub
+
+    assert _extract_sub("token-without-bearer") is None
+
+
+def test_extract_sub_returns_none_for_empty_string() -> None:
+    from app.middleware.rate_limit import _extract_sub
+
+    assert _extract_sub("") is None
+
+
+def test_extract_sub_returns_none_for_malformed_jwt() -> None:
+    from app.middleware.rate_limit import _extract_sub
+
+    assert _extract_sub("Bearer not.a.valid.jwt.parts") is None
+
+
+def test_extract_sub_returns_none_when_payload_has_no_sub() -> None:
+    from app.middleware.rate_limit import _extract_sub
+
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(b'{"role":"user"}').rstrip(b"=").decode()
+    assert _extract_sub(f"Bearer {header}.{payload}.sig") is None
+
+
+def test_extract_sub_returns_none_when_sub_is_not_a_string() -> None:
+    from app.middleware.rate_limit import _extract_sub
+
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(b'{"sub": 12345}').rstrip(b"=").decode()
+    assert _extract_sub(f"Bearer {header}.{payload}.sig") is None
+
+
+def test_extract_sub_returns_none_when_payload_is_invalid_base64() -> None:
+    from app.middleware.rate_limit import _extract_sub
+
+    assert _extract_sub("Bearer header.!!!invalid!!!.sig") is None
+
+
+# ── Middleware: no Redis (fail open) ──────────────────────────────────────────
+
+
+def test_middleware_allows_request_when_redis_is_none(client: TestClient) -> None:
+    # app.state.redis is None (set by lifespan since REDIS_URL is not configured)
+    response = client.get("/health")
+
+    assert response.status_code == 200
+
+
+# ── Middleware: rate limit not exceeded ────────────────────────────────────────
+
+
+def test_general_endpoint_below_limit_returns_non_429(client: TestClient) -> None:
+    app.state.redis = _make_redis_mock(count=1)
+    response = client.get(
+        "/v1/workouts",
+        headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+    )
+
+    assert response.status_code != 429
+
+
+def test_ai_endpoint_below_limit_returns_non_429(client: TestClient) -> None:
+    app.state.redis = _make_redis_mock(count=1)
+    response = client.get(
+        "/v1/jobs/00000000-0000-0000-0000-000000000001",
+        headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+    )
+
+    assert response.status_code != 429
+
+
+# ── Middleware: rate limit exceeded ───────────────────────────────────────────
+
+
+def test_general_endpoint_returns_429_when_limit_exceeded(client: TestClient) -> None:
+    app.state.redis = _make_redis_mock(count=101)
+    response = client.get(
+        "/v1/workouts",
+        headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+    )
+
+    assert response.status_code == 429
+
+
+def test_ai_endpoint_returns_429_when_limit_exceeded(client: TestClient) -> None:
+    app.state.redis = _make_redis_mock(count=11)
+    response = client.get(
+        "/v1/jobs/00000000-0000-0000-0000-000000000001",
+        headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+    )
+
+    assert response.status_code == 429
+
+
+def test_auth_endpoint_returns_429_when_ip_limit_exceeded(client: TestClient) -> None:
+    app.state.redis = _make_redis_mock(count=6)
+    response = client.post("/v1/auth/login")
+
+    assert response.status_code == 429
+
+
+def test_rate_limit_response_body_has_correct_error_code(client: TestClient) -> None:
+    app.state.redis = _make_redis_mock(count=101)
+    response = client.get(
+        "/v1/workouts",
+        headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+    )
+
+    assert response.json()["error_code"] == "rate_limit_exceeded"
+
+
+def test_rate_limit_response_body_has_message(client: TestClient) -> None:
+    app.state.redis = _make_redis_mock(count=101)
+    response = client.get(
+        "/v1/workouts",
+        headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+    )
+
+    assert response.json()["message"] != ""
+
+
+def test_rate_limit_response_body_has_request_id(client: TestClient) -> None:
+    app.state.redis = _make_redis_mock(count=101)
+    response = client.get(
+        "/v1/workouts",
+        headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+    )
+
+    body = response.json()
+    assert "request_id" in body
+
+
+def test_rate_limit_response_includes_retry_after_header(client: TestClient) -> None:
+    app.state.redis = _make_redis_mock(count=101)
+    response = client.get(
+        "/v1/workouts",
+        headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+    )
+
+    assert "retry-after" in response.headers
+
+
+def test_retry_after_header_value_is_a_positive_integer(client: TestClient) -> None:
+    app.state.redis = _make_redis_mock(count=101)
+    response = client.get(
+        "/v1/workouts",
+        headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+    )
+
+    retry_after = int(response.headers["retry-after"])
+    assert 0 < retry_after <= 60
+
+
+def test_health_endpoint_is_never_rate_limited(client: TestClient) -> None:
+    app.state.redis = _make_redis_mock(count=9999)
+    response = client.get("/health")
+
+    assert response.status_code == 200
+
+
+# ── Middleware: Redis failure (fail open) ─────────────────────────────────────
+
+
+def test_middleware_fails_open_when_redis_raises(client: TestClient) -> None:
+    mock = MagicMock()
+    mock.incr = AsyncMock(side_effect=ConnectionError("Redis unavailable"))
+    mock.expire = AsyncMock(return_value=True)
+    app.state.redis = mock
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+
+
+def test_middleware_fails_open_and_logs_error_on_redis_failure(
+    client: TestClient,
+) -> None:
+    mock = MagicMock()
+    mock.incr = AsyncMock(side_effect=OSError("connection refused"))
+    app.state.redis = mock
+
+    with patch("app.middleware.rate_limit.logger") as mock_logger:
+        client.get(
+            "/v1/workouts",
+            headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+        )
+        mock_logger.error.assert_called_once()
+
+
+# ── Middleware: identifier fallback ───────────────────────────────────────────
+
+
+def test_general_endpoint_uses_ip_when_no_auth_header(client: TestClient) -> None:
+    # No Authorization header — middleware falls back to request.client.host
+    app.state.redis = _make_redis_mock(count=101)
+    response = client.get("/v1/workouts")
+
+    assert response.status_code == 429
+
+
+def test_incr_is_called_with_expected_key_format(client: TestClient) -> None:
+    mock = _make_redis_mock(count=1)
+    app.state.redis = mock
+
+    user_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    client.get(
+        "/v1/workouts",
+        headers={"Authorization": f"Bearer {_make_fake_jwt(user_id)}"},
+    )
+
+    window = int(time.time()) // 60
+    expected_key = f"{user_id}:general:{window}"
+    mock.incr.assert_called_once_with(expected_key)
+
+
+def test_expire_called_on_first_request(client: TestClient) -> None:
+    # When INCR returns 1, EXPIRE must be called to establish the TTL
+    mock = _make_redis_mock(count=1)
+    app.state.redis = mock
+
+    client.get(
+        "/v1/workouts",
+        headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+    )
+
+    mock.expire.assert_called_once_with(
+        mock.incr.call_args[0][0],
+        60,
+    )
+
+
+def test_expire_not_called_on_subsequent_requests(client: TestClient) -> None:
+    # When INCR returns > 1, key already has a TTL — EXPIRE must not reset it
+    mock = _make_redis_mock(count=5)
+    app.state.redis = mock
+
+    client.get(
+        "/v1/workouts",
+        headers={"Authorization": f"Bearer {_make_fake_jwt('user-1')}"},
+    )
+
+    mock.expire.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `RateLimitMiddleware` (`app/middleware/rate_limit.py`) using Redis fixed-window counters
- Three tiers: general endpoints 100/min per user, AI endpoints (`/v1/jobs`) 10/min per user, auth endpoints 5/min per IP
- HTTP 429 + `Retry-After` header when limit exceeded; fails open and logs `ERROR` when Redis is unavailable
- Adds `redis_url`, `rate_limit_general`, `rate_limit_ai`, `rate_limit_auth` to `Settings`
- Redis client initialised in app lifespan, stored in `app.state.redis`; skipped (no-op) when `REDIS_URL` is not set
- 33 new tests — all passing; 97.48% total coverage

## Design notes

- Rate limit key format: `{user_id|ip}:{category}:{window_minute}` per ARCHITECTURE.md
- User ID extracted from JWT payload without signature verification (auth dependency validates later); falls back to client IP when no Bearer token present
- `CorrelationIDMiddleware` registered as the outer layer so `request_id` is populated in 429 bodies
- `/health` endpoint is excluded from rate limiting (Railway health checks)
- Middleware is a no-op when `app.state.redis is None` — correct for test and local dev without Redis

## Test plan

- [x] `test_classify_*` — all endpoint tiers correctly identified
- [x] `test_extract_sub_*` — JWT parsing edge cases (no bearer, malformed, missing/wrong-type sub)
- [x] 429 returned for general (count=101), AI (count=11), auth (count=6)
- [x] `Retry-After` header present and in range (1–60)
- [x] Fail open when Redis raises `ConnectionError` / `OSError`
- [x] Error log written on Redis failure
- [x] `EXPIRE` called only on first request (count==1); skipped on subsequent
- [x] INCR key format matches `{user_id}:general:{window}`
- [x] `/health` never rate-limited regardless of counter value
- [x] All 297 tests passing, 97.48% coverage, ruff + mypy clean

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)