### PR TITLE
Fix flaky onboarding UI tests (iPhone SE / narrow screen)

### DIFF
--- a/PRLifts/PRLifts/Onboarding/UnitPreferenceScreen.swift
+++ b/PRLifts/PRLifts/Onboarding/UnitPreferenceScreen.swift
@@ -171,8 +171,10 @@ private struct UnitCard: View {
                 radius: 8, x: 0, y: 0
             )
         }
+        .contentShape(Rectangle())
         .animation(PRAnimation.quick, value: isSelected)
         .accessibilityLabel("\(label), \(sublabel)")
+        .accessibilityIdentifier("\(label), \(sublabel)")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }

--- a/PRLifts/PRLiftsUITests/Onboarding/OnboardingUITests.swift
+++ b/PRLifts/PRLiftsUITests/Onboarding/OnboardingUITests.swift
@@ -158,7 +158,7 @@ final class OnboardingUITests: XCTestCase {
     private func navigateToDisplayName() {
         app.buttons["Get started"].tap()
         let emailField = app.textFields["Email address"]
-        guard emailField.waitForExistence(timeout: 3) else { return }
+        XCTAssertTrue(emailField.waitForExistence(timeout: 5))
         emailField.tap()
         emailField.typeText("test@example.com")
         app.buttons["Continue"].tap()
@@ -167,7 +167,7 @@ final class OnboardingUITests: XCTestCase {
     private func navigateToUnitPreference() {
         navigateToDisplayName()
         let field = app.textFields["Display name, 0 of 50 characters"]
-        guard field.waitForExistence(timeout: 5) else { return }
+        XCTAssertTrue(field.waitForExistence(timeout: 5))
         field.tap()
         field.typeText("Sarosh")
         app.buttons["Continue"].tap()


### PR DESCRIPTION
Follow-up fix for PR #58 (merged). Two tests were failing in Xcode Cloud.

## Root causes

**Test 1 — `testDisplayNameScreen_backButton_returnsToSignIn` (iPhone 16)**
`navigateToDisplayName()` used `guard emailField.waitForExistence(timeout: 3) else { return }` — a silent early return that swallowed navigation failures. When focus on the email field wasn't established before `typeText`, the error was eaten and the test kept running against the wrong screen.

**Test 2 — `testUnitPreferenceScreen_weightCardSelection_toggling` (iPhone SE)**
Same silent-guard issue in `navigateToUnitPreference()`. Additionally, `UnitCard` applied `clipShape(RoundedRectangle(...))` to the inner VStack without a corresponding `.contentShape(Rectangle())` on the Button, meaning the hit-test area could be smaller than the card's visual frame on narrow screens.

## Changes

**`OnboardingUITests.swift`**
- `navigateToDisplayName()`: `guard...else { return }` → `XCTAssertTrue(emailField.waitForExistence(timeout: 5))`. Failures now surface immediately with a clear assertion message rather than silently continuing.
- `navigateToUnitPreference()`: same fix.

**`UnitPreferenceScreen.swift` — `UnitCard`**
- Added `.contentShape(Rectangle())` on the `Button` to guarantee the full card rectangle is the tap target regardless of `clipShape` on inner content. Satisfies the 44×44pt minimum touch target requirement from STANDARDS.md §6.5.
- Added `.accessibilityIdentifier("\(label), \(sublabel)")` for deterministic XCUITest element lookups.

## Test plan

- [x] `testDisplayNameScreen_backButton_returnsToSignIn` — passes on iPhone 16e
- [x] `testUnitPreferenceScreen_weightCardSelection_toggling` — passes on iPhone 16e
- [x] Full `OnboardingUITests` suite — 19/19 pass on iPhone 16e simulator
- [x] Pre-commit hook: Xcode build clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)