### PR TITLE
Add Xcode Cloud environment parity — SE simulator and strict concurrency

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,31 +1,36 @@
 #!/usr/bin/env bash
-# pre-commit: run Swift build check (if .swift files staged) and ruff checks.
-# Blocks the commit if any check fails so issues are caught before Xcode Cloud.
+# pre-commit: run iOS tests on iPhone SE simulator (if .swift files staged)
+# and ruff checks. Blocks the commit if any check fails so layout, touch
+# target, and concurrency issues are caught before Xcode Cloud.
+#
+# iPhone SE (3rd generation) UDID: 6C107B89-D600-4A9E-81BA-3606168CD8A3
+# Use this simulator for local test runs — it is the minimum supported
+# screen size and catches layout regressions that wider devices miss.
 
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-# --- Swift build check ---
+# --- iOS test run ---
 
 STAGED_SWIFT=$(git diff --cached --name-only --diff-filter=ACM | grep '\.swift$' || true)
 
 if [ -n "$STAGED_SWIFT" ]; then
-  echo "--- pre-commit: xcodebuild (Swift files staged) ---"
-  xcodebuild build \
+  echo "--- pre-commit: xcodebuild test (iPhone SE, Swift files staged) ---"
+  xcodebuild test \
     -project "$REPO_ROOT/PRLifts/PRLifts.xcodeproj" \
     -scheme PRLifts \
-    -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+    -destination 'platform=iOS Simulator,id=6C107B89-D600-4A9E-81BA-3606168CD8A3' \
     -quiet 2>&1
-  BUILD_STATUS=$?
-  if [ $BUILD_STATUS -ne 0 ]; then
+  TEST_STATUS=$?
+  if [ $TEST_STATUS -ne 0 ]; then
     echo ""
-    echo "error: Xcode build failed — commit blocked."
-    echo "Fix the build errors above, then commit again."
-    echo "Tip: Cmd+B in Xcode shows the same errors in the Issue Navigator."
+    echo "error: Tests failed on iPhone SE simulator — commit blocked."
+    echo "Fix the failing tests above, then commit again."
+    echo "Tip: Product → Test (⌘U) in Xcode runs the same suite."
     exit 1
   fi
-  echo "Xcode build succeeded."
+  echo "Xcode tests passed."
 fi
 
 # --- Python / backend checks ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ Full details in docs/PROJECT_MANAGEMENT.md. Summary for every session:
 - Tests written and passing at 90% coverage
 - No linting violations (SwiftLint / Ruff): both `ruff check .` and `ruff format --check .` must pass in `backend/`
 - No mypy errors
-- **iOS PRs: run Cmd+B in Xcode and confirm 0 errors, 0 warnings before opening the PR. A build failure is a blocking PR issue.**
+- **iOS PRs: run Cmd+B in Xcode and confirm 0 errors, 0 warnings before opening the PR. A build failure is a blocking PR issue. Run UI tests on the iPhone SE (3rd generation) simulator before pushing — UDID `6C107B89-D600-4A9E-81BA-3606168CD8A3`. It is the minimum supported screen size and catches layout and touch target regressions that wider devices miss.**
 - PR opened with clear description
 - ARCHITECTURE.md updated if any decision was made
 

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Xcode Cloud — post-clone lifecycle script.
+# Runs automatically after the repository is cloned in every Xcode Cloud build.
+#
+# Purpose: enforce environment parity between local development and CI.
+# Without this, Xcode Cloud can compile with looser concurrency checking than
+# local builds, letting data-race warnings reach the reviewer instead of the
+# developer.
+
+set -euo pipefail
+
+# Enforce Swift 6 complete concurrency checking on every compilation unit.
+# Matches the SWIFT_STRICT_CONCURRENCY=complete setting used locally so that
+# the same concurrency warnings and errors surface in both environments.
+export SWIFT_STRICT_CONCURRENCY=complete

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -843,6 +843,8 @@ Button(action: logSet) {
 - Minimum touch target 44×44pt on all interactive elements
 - VoiceOver reading order is logical — use `.accessibilitySortPriority` where needed
 - Accessibility tests run in CI via `XCTOSSignpostMetric` accessibility audit
+- UI tests must be run against iPhone SE (3rd generation) simulator before opening any iOS PR. The SE's 320pt width is the minimum supported screen size. Touch targets must meet 44×44pt minimum on all screen sizes.
+- Never use `guard element.waitForExistence() else { return }` in UI tests — use `XCTAssertTrue(element.waitForExistence(timeout:))` so failures are loud and immediate.
 
 ### 6.6 NWPathMonitor Thread Safety
 


### PR DESCRIPTION
## Summary

- **`ci_scripts/ci_post_clone.sh`** — new Xcode Cloud post-clone script that exports `SWIFT_STRICT_CONCURRENCY=complete`. Without this, Xcode Cloud can compile with looser concurrency checking than local builds, letting data-race issues reach the reviewer instead of the developer.
- **`.githooks/pre-commit`** — replaces `xcodebuild build` (iPhone 17 Pro) with `xcodebuild test` on iPhone SE (3rd generation, UDID `6C107B89-D600-4A9E-81BA-3606168CD8A3`). Tests on the SE catch layout and touch target regressions at the minimum supported screen size before the branch is pushed, the class of issue that caused the Xcode Cloud failures fixed in PR #60.
- **`docs/STANDARDS.md` §6.5** — two new rules: require UI tests on the SE simulator before opening any iOS PR; prohibit `guard element.waitForExistence() else { return }` in favour of `XCTAssertTrue(element.waitForExistence(timeout:))`.
- **`CLAUDE.md`** — iPhone SE UDID added to the iOS Definition of Done so it is visible at the start of every session.

## Test plan

- [x] Pre-commit hook runs clean on this commit (no `.swift` files staged → test section skipped, ruff passes)
- [x] `ci_post_clone.sh` is executable (`-rwxr-xr-x`, tracked by git as mode 100755)
- [x] Hook wording updated to reference SE UDID and new error message
- [x] STANDARDS.md and CLAUDE.md diffs are additive — no existing content changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)