### PR TITLE
[iOS] HomeScreen UI — tab bar, empty state, streak card, Future Self teaser

### DIFF
--- a/PRLifts/PRLifts/Components/PRCard.swift
+++ b/PRLifts/PRLifts/Components/PRCard.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct PRCard<Content: View>: View {
+    var padding: CGFloat = PRSpacing.cardPadding
+    var radius: CGFloat = PRRadius.large
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        content()
+            .padding(padding)
+            .background(Color.prBackgroundSec)
+            .clipShape(RoundedRectangle(cornerRadius: radius))
+            .overlay(
+                RoundedRectangle(cornerRadius: radius)
+                    .stroke(Color.prBorder, lineWidth: 1)
+            )
+            .shadow(
+                color: PRShadow.low.color,
+                radius: PRShadow.low.radius,
+                x: PRShadow.low.x,
+                y: PRShadow.low.y
+            )
+    }
+}

--- a/PRLifts/PRLifts/ContentView.swift
+++ b/PRLifts/PRLifts/ContentView.swift
@@ -6,7 +6,7 @@ struct ContentView: View {
 
     var body: some View {
         if hasCompletedOnboarding {
-            HomeScreen()
+            MainTabView()
         } else {
             OnboardingCoordinator {
                 hasCompletedOnboarding = true

--- a/PRLifts/PRLifts/DesignSystem/DesignTokens+Spacing.swift
+++ b/PRLifts/PRLifts/DesignSystem/DesignTokens+Spacing.swift
@@ -1,4 +1,4 @@
-import CoreFoundation
+import SwiftUI
 
 enum PRSpacing {
     static let xxxSmall: CGFloat = 4
@@ -16,6 +16,19 @@ enum PRSpacing {
     static let cardGap:           CGFloat = xxSmall
     static let buttonHeight:      CGFloat = 50
     static let minimumTouchTarget: CGFloat = 44
+}
+
+struct PRShadow {
+    let color: Color
+    let radius: CGFloat
+    let x: CGFloat
+    let y: CGFloat
+
+    static let low    = PRShadow(color: .black.opacity(0.12), radius: 4,  x: 0, y: 2)
+    static let medium = PRShadow(color: .black.opacity(0.20), radius: 8,  x: 0, y: 4)
+    static let high   = PRShadow(color: .black.opacity(0.28), radius: 16, x: 0, y: 8)
+    static let brand  = PRShadow(color: Color("PRBrand").opacity(0.35),  radius: 16, x: 0, y: 6)
+    static let accent = PRShadow(color: Color("PRAccent").opacity(0.30), radius: 16, x: 0, y: 6)
 }
 
 enum PRRadius {

--- a/PRLifts/PRLifts/Home/ExercisesPlaceholderView.swift
+++ b/PRLifts/PRLifts/Home/ExercisesPlaceholderView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct ExercisesPlaceholderView: View {
+    var body: some View {
+        ZStack {
+            Color.prBackground.ignoresSafeArea()
+            VStack(spacing: PRSpacing.medium) {
+                Image(systemName: "list.bullet")
+                    .font(.system(size: 48))
+                    .foregroundColor(.prTextTertiary)
+                    .accessibilityHidden(true)
+                Text("Exercises")
+                    .font(.prHeadlineLarge)
+                    .foregroundColor(.prTextPrimary)
+                Text("Browse and search exercises here.")
+                    .font(.prBodySecondary)
+                    .foregroundColor(.prTextSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, PRSpacing.large)
+        }
+    }
+}

--- a/PRLifts/PRLifts/Home/HistoryPlaceholderView.swift
+++ b/PRLifts/PRLifts/Home/HistoryPlaceholderView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct HistoryPlaceholderView: View {
+    var body: some View {
+        ZStack {
+            Color.prBackground.ignoresSafeArea()
+            VStack(spacing: PRSpacing.medium) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .font(.system(size: 48))
+                    .foregroundColor(.prTextTertiary)
+                    .accessibilityHidden(true)
+                Text("History")
+                    .font(.prHeadlineLarge)
+                    .foregroundColor(.prTextPrimary)
+                Text("Your workout history will appear here.")
+                    .font(.prBodySecondary)
+                    .foregroundColor(.prTextSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, PRSpacing.large)
+        }
+    }
+}

--- a/PRLifts/PRLifts/Home/HomeScreen.swift
+++ b/PRLifts/PRLifts/Home/HomeScreen.swift
@@ -1,15 +1,230 @@
 import SwiftUI
 
 struct HomeScreen: View {
+    @State private var showComingSoon = false
+    private let streak = 0
+
     var body: some View {
-        Text("PRLifts")
-            .font(.prDisplayMedium)
-            .foregroundColor(.prTextPrimary)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.prBackground.ignoresSafeArea())
+        ZStack {
+            Color.prBackground.ignoresSafeArea()
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 10) {
+                    headerRow
+                        .padding(.top, PRSpacing.xxSmall)
+                    streakCard
+                    startWorkoutButton
+                    statsGrid
+                    recentPRsSection
+                    futureSelfCard
+                }
+                .padding(.horizontal, PRSpacing.screenHorizontal)
+                .padding(.bottom, PRSpacing.large)
+            }
+        }
+        .alert("Coming Soon", isPresented: $showComingSoon) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Workout logging is coming soon.")
+        }
+    }
+
+    // MARK: Header
+
+    private var headerRow: some View {
+        HStack {
+            Text("PRLifts")
+                .font(.prHeadlineLarge)
+                .foregroundColor(.prTextPrimary)
+            Spacer()
+            Circle()
+                .fill(Color.prBackgroundTer)
+                .frame(width: 32, height: 32)
+                .overlay(
+                    Image(systemName: "person.fill")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.prTextSecondary)
+                )
+                .accessibilityLabel("Profile avatar")
+        }
+    }
+
+    // MARK: Streak Card
+
+    private var streakCard: some View {
+        HStack(spacing: PRSpacing.xSmall) {
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color.prBrand)
+                .frame(width: 48, height: 48)
+                .overlay(
+                    Image(systemName: "flame.fill")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundColor(.white)
+                )
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: PRSpacing.xxxSmall) {
+                Text("Keep it going!")
+                    .font(.prCaption)
+                    .foregroundColor(.prTextSecondary)
+                Text("\(streak)-day streak")
+                    .font(.prHeadlineLarge)
+                    .foregroundColor(.prTextPrimary)
+
+                HStack(spacing: 4) {
+                    ForEach(0..<7, id: \.self) { day in
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(day < streak ? Color.prBrand : Color.prBackgroundTer)
+                            .frame(height: 4)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .accessibilityLabel("Streak progress: \(streak) of 7 days this week")
+            }
+        }
+        .padding(PRSpacing.cardPadding)
+        .background(
+            LinearGradient(
+                colors: [Color.prBrand.opacity(0.22), Color.prBrand.opacity(0.08)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: PRRadius.large))
+        .overlay(
+            RoundedRectangle(cornerRadius: PRRadius.large)
+                .stroke(Color.prBrand.opacity(0.40), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.12), radius: 4, x: 0, y: 2)
+    }
+
+    // MARK: Start Workout Button
+
+    private var startWorkoutButton: some View {
+        PRButton(label: "Start Workout", icon: "plus") {
+            showComingSoon = true
+        }
+    }
+
+    // MARK: Stats Grid
+
+    private var statsGrid: some View {
+        HStack(spacing: PRSpacing.xxSmall) {
+            statCard(value: "0", label: "Workouts", valueColor: .prBrand)
+            statCard(value: "0", label: "Personal Records", valueColor: .prAccent)
+        }
+    }
+
+    private func statCard(value: String, label: String, valueColor: Color) -> some View {
+        PRCard {
+            VStack(spacing: PRSpacing.xxxSmall) {
+                Text(value)
+                    .font(.prDataLarge)
+                    .foregroundColor(valueColor)
+                Text(label)
+                    .font(.prCaption)
+                    .foregroundColor(.prTextSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, PRSpacing.xxSmall)
+        }
+    }
+
+    // MARK: Recent PRs Section
+
+    private var recentPRsSection: some View {
+        VStack(spacing: PRSpacing.xSmall) {
+            HStack {
+                Text("Recent PRs")
+                    .font(.prHeadlineLarge)
+                    .foregroundColor(.prTextPrimary)
+                Spacer()
+                Button("See all →") {}
+                    .font(.prCaption)
+                    .foregroundColor(.prBrandLight)
+                    .accessibilityLabel("See all personal records")
+                    .disabled(true)
+            }
+
+            emptyPRsCard
+        }
+    }
+
+    private var emptyPRsCard: some View {
+        PRCard {
+            VStack(spacing: PRSpacing.medium) {
+                Image(systemName: "dumbbell.fill")
+                    .font(.system(size: 36))
+                    .foregroundColor(.prTextTertiary)
+                    .accessibilityHidden(true)
+
+                VStack(spacing: PRSpacing.xxxSmall) {
+                    Text("Ready when you are.")
+                        .font(.prHeadlineMedium)
+                        .foregroundColor(.prTextPrimary)
+                    Text("Tap to log your first workout.")
+                        .font(.prBodySecondary)
+                        .foregroundColor(.prTextSecondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, PRSpacing.large)
+        }
+    }
+
+    // MARK: Future Self Teaser
+
+    private var futureSelfCard: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: PRSpacing.xxxSmall) {
+                Text("Future Self")
+                    .font(.prCaptionSmall)
+                    .fontWeight(.bold)
+                    .textCase(.uppercase)
+                    .tracking(0.5)
+                    .foregroundColor(.prAccent)
+                    .accessibilityLabel("Future Self")
+                Text("See your future physique")
+                    .font(.prHeadlineMedium)
+                    .foregroundColor(.prTextPrimary)
+                Text("Complete your profile to unlock AI-generated motivation.")
+                    .font(.prCaption)
+                    .foregroundColor(.prTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.prTextTertiary)
+                .accessibilityHidden(true)
+        }
+        .padding(PRSpacing.cardPadding)
+        .background(
+            LinearGradient(
+                colors: [
+                    Color.prCelebrationStart.opacity(0.10),
+                    Color.prCelebrationEnd.opacity(0.06)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: PRRadius.large))
+        .overlay(
+            RoundedRectangle(cornerRadius: PRRadius.large)
+                .stroke(Color.prAccent.opacity(0.30), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.12), radius: 4, x: 0, y: 2)
     }
 }
 
 #Preview {
     HomeScreen()
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Light") {
+    HomeScreen()
+        .preferredColorScheme(.light)
 }

--- a/PRLifts/PRLifts/Home/MainTabView.swift
+++ b/PRLifts/PRLifts/Home/MainTabView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+enum PRTab { case home, history, exercises, profile }
+
+struct MainTabView: View {
+    @State private var selectedTab: PRTab = .home
+
+    init() {
+        UITabBar.appearance().backgroundColor = UIColor(Color.prBackgroundSec)
+        UITabBar.appearance().unselectedItemTintColor = UIColor(Color.prTextTertiary)
+    }
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            HomeScreen()
+                .tabItem { Label("Home", systemImage: "house.fill") }
+                .tag(PRTab.home)
+            HistoryPlaceholderView()
+                .tabItem { Label("History", systemImage: "clock.arrow.circlepath") }
+                .tag(PRTab.history)
+            ExercisesPlaceholderView()
+                .tabItem { Label("Exercises", systemImage: "list.bullet") }
+                .tag(PRTab.exercises)
+            ProfilePlaceholderView()
+                .tabItem { Label("Profile", systemImage: "person.circle") }
+                .tag(PRTab.profile)
+        }
+        .tint(Color.prBrand)
+    }
+}
+
+#Preview {
+    MainTabView()
+}

--- a/PRLifts/PRLifts/Home/ProfilePlaceholderView.swift
+++ b/PRLifts/PRLifts/Home/ProfilePlaceholderView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct ProfilePlaceholderView: View {
+    var body: some View {
+        ZStack {
+            Color.prBackground.ignoresSafeArea()
+            VStack(spacing: PRSpacing.medium) {
+                Image(systemName: "person.circle")
+                    .font(.system(size: 48))
+                    .foregroundColor(.prTextTertiary)
+                    .accessibilityHidden(true)
+                Text("Profile")
+                    .font(.prHeadlineLarge)
+                    .foregroundColor(.prTextPrimary)
+                Text("Your profile and settings will appear here.")
+                    .font(.prBodySecondary)
+                    .foregroundColor(.prTextSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, PRSpacing.large)
+        }
+    }
+}

--- a/PRLifts/PRLifts/PRLiftsApp.swift
+++ b/PRLifts/PRLifts/PRLiftsApp.swift
@@ -6,6 +6,9 @@ struct PRLiftsApp: App {
         if ProcessInfo.processInfo.arguments.contains("ResetOnboarding") {
             UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
         }
+        if ProcessInfo.processInfo.arguments.contains("SkipOnboarding") {
+            UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+        }
     }
 
     var body: some Scene {

--- a/PRLifts/PRLiftsUITests/Home/HomeScreenUITests.swift
+++ b/PRLifts/PRLiftsUITests/Home/HomeScreenUITests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+final class HomeScreenUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["UITesting", "SkipOnboarding"]
+        app.launch()
+    }
+
+    // MARK: Tab Bar
+
+    func testHomeScreen_tabBar_showsHomeTab() {
+        XCTAssertTrue(app.tabBars.buttons["Home"].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_tabBar_showsHistoryTab() {
+        XCTAssertTrue(app.tabBars.buttons["History"].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_tabBar_showsExercisesTab() {
+        XCTAssertTrue(app.tabBars.buttons["Exercises"].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_tabBar_showsProfileTab() {
+        XCTAssertTrue(app.tabBars.buttons["Profile"].waitForExistence(timeout: 3))
+    }
+
+    // MARK: Home tab content
+
+    func testHomeScreen_wordmark_isPresent() {
+        XCTAssertTrue(app.staticTexts["PRLifts"].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_streakCard_isPresent() {
+        XCTAssertTrue(app.staticTexts["0-day streak"].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_startWorkoutButton_isPresent() {
+        XCTAssertTrue(app.buttons["Start Workout"].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_emptyState_showsReadyCopy() {
+        XCTAssertTrue(app.staticTexts["Ready when you are."].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_emptyState_showsFirstWorkoutCopy() {
+        XCTAssertTrue(app.staticTexts["Tap to log your first workout."].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_futureSelfCard_isPresent() {
+        app.swipeUp()
+        XCTAssertTrue(app.staticTexts["See your future physique"].waitForExistence(timeout: 5))
+    }
+
+    // MARK: Tab switching
+
+    func testHomeScreen_tabSwitch_historyShowsPlaceholder() {
+        app.tabBars.buttons["History"].tap()
+        XCTAssertTrue(app.staticTexts["History"].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_tabSwitch_exercisesShowsPlaceholder() {
+        app.tabBars.buttons["Exercises"].tap()
+        XCTAssertTrue(app.staticTexts["Exercises"].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_tabSwitch_profileShowsPlaceholder() {
+        app.tabBars.buttons["Profile"].tap()
+        XCTAssertTrue(app.staticTexts["Profile"].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_tabSwitch_returnToHome_showsWordmark() {
+        app.tabBars.buttons["History"].tap()
+        app.tabBars.buttons["Home"].tap()
+        XCTAssertTrue(app.staticTexts["PRLifts"].waitForExistence(timeout: 3))
+    }
+
+    // MARK: Start Workout interaction
+
+    func testHomeScreen_startWorkoutButton_showsComingSoonAlert() {
+        app.buttons["Start Workout"].tap()
+        XCTAssertTrue(app.alerts["Coming Soon"].waitForExistence(timeout: 3))
+    }
+
+    func testHomeScreen_comingSoonAlert_dismissesOnOK() {
+        app.buttons["Start Workout"].tap()
+        XCTAssertTrue(app.alerts["Coming Soon"].waitForExistence(timeout: 3))
+        app.alerts["Coming Soon"].buttons["OK"].tap()
+        XCTAssertFalse(app.alerts["Coming Soon"].exists)
+    }
+}


### PR DESCRIPTION
## Summary

- Implements issue #44 — HomeScreen UI (closes #44)
- Adds `MainTabView` with 4 tabs: Home, History, Exercises, Profile; tab bar styled via `UITabBar.appearance()` per Handoff Bundle spec
- Implements full HomeScreen empty state: streak card (0-day, 7-pill progress bar), Start Workout button (coming soon alert), stats grid (0 workouts / 0 PRs), empty PR state with spec copy ("Ready when you are. Tap to log your first workout."), Future Self teaser card
- Adds `PRCard` shared component and `PRShadow` design tokens (both per Handoff Bundle v2)
- Adds placeholder views for History, Exercises, Profile tabs
- Adds `SkipOnboarding` launch argument for direct HomeScreen UI testing
- 16 new UI tests covering tab bar, empty state copy, Start Workout alert, tab switching — all passing on iPhone SE (3rd generation) simulator

## Design spec

- Visual spec: design/handoff-screens.html screen 05
- Component spec: design/Handoff Bundle.html — PRCard, PRTabBar, PRButton, PRShadow

## Test plan

- [x] All 16 HomeScreen UI tests pass on iPhone SE (3rd generation) simulator
- [x] All 19 existing onboarding UI tests pass (no regressions)
- [x] Pre-commit hook (full test suite) passes
- [ ] Verify visually in Xcode Simulator before merge: tab switching, Future Self card scroll, Coming Soon alert, dark/light mode

## Notes

- Start Workout button shows "Coming Soon" alert — ActiveWorkoutScreen not in scope for this sprint
- History, Exercises, Profile tabs show placeholder screens — content in future sprints
- Future Self teaser is display-only; legal prerequisites for `future_self_enabled` remain unmet

🤖 Generated with [Claude Code](https://claude.com/claude-code)