### PR TITLE
Add export compliance declaration — app uses no non-exempt encryption

### DIFF
--- a/PRLifts/PRLifts.xcodeproj/project.pbxproj
+++ b/PRLifts/PRLifts.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 				DEVELOPMENT_TEAM = 5R3A23MRJW;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -450,6 +451,7 @@
 				DEVELOPMENT_TEAM = 5R3A23MRJW;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;


### PR DESCRIPTION
Adds ITSAppUsesNonExemptEncryption = NO to the Xcode project build 
settings for both Debug and Release configurations.

The app uses only standard HTTPS for network communication which is 
exempt from US export regulations. This declaration is required for 
App Store Connect uploads — without it Xcode Cloud fails at the 
"Preparing build for App Store Connect" step.