### PR TITLE
Add schema consistency CI test and SchemaMapping.swift registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ backend/.pytest_cache/
 backend/.coverage
 backend/**/__pycache__/
 backend/.pytest_cache/
+PRLifts/build/
+PRLiftsCore/build/

--- a/PRLiftsCore/Sources/PRLiftsCore/Migration/PRLiftsSchema.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Migration/PRLiftsSchema.swift
@@ -11,7 +11,8 @@ public enum PRLiftsSchema {
             WorkoutSet.self,
             PersonalRecord.self,
             Job.self,
-            SyncEventLog.self
+            SyncEventLog.self,
+            SupportReport.self
         ]
     }
 

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/SchemaMapping.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/SchemaMapping.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+// MARK: - Schema Mapping Registry
+//
+// Declarative registry of PostgreSQL → SwiftData column mappings.
+// Validated by backend/scripts/validate_schema_mapping.py as part of backend-ci.
+//
+// Rules:
+//  - Every [iOS]-annotated column in docs/SCHEMA.md must have an entry here.
+//  - [BE] columns must never appear here.
+//  - swiftProperty must be the lowerCamelCase equivalent of the pg_column name.
+//  - swiftType must be compatible with the PostgreSQL type.
+//
+// Do not edit without a corresponding SCHEMA.md update in the same PR.
+
+public enum SchemaMapping {
+    public struct Column: Sendable {
+        public let table: String
+        public let pgColumn: String
+        public let pgType: String
+        public let swiftModel: String
+        public let swiftProperty: String
+        public let swiftType: String
+    }
+
+    public static let columns: [Column] = [
+
+        // MARK: - user
+
+        Column(table: "user", pgColumn: "id",                   pgType: "UUID",         swiftModel: "User", swiftProperty: "id",                  swiftType: "UUID"),
+        Column(table: "user", pgColumn: "email",                pgType: "TEXT",         swiftModel: "User", swiftProperty: "email",               swiftType: "String?"),
+        Column(table: "user", pgColumn: "display_name",         pgType: "TEXT",         swiftModel: "User", swiftProperty: "displayName",         swiftType: "String?"),
+        Column(table: "user", pgColumn: "avatar_url",           pgType: "TEXT",         swiftModel: "User", swiftProperty: "avatarURL",           swiftType: "String?"),
+        Column(table: "user", pgColumn: "unit_preference",      pgType: "weight_unit",  swiftModel: "User", swiftProperty: "unitPreference",      swiftType: "WeightUnit"),
+        Column(table: "user", pgColumn: "measurement_unit",     pgType: "measurement_unit", swiftModel: "User", swiftProperty: "measurementUnit", swiftType: "MeasurementUnit"),
+        Column(table: "user", pgColumn: "date_of_birth",        pgType: "DATE",         swiftModel: "User", swiftProperty: "dateOfBirth",         swiftType: "Date?"),
+        Column(table: "user", pgColumn: "gender",               pgType: "gender",       swiftModel: "User", swiftProperty: "gender",              swiftType: "Gender"),
+        Column(table: "user", pgColumn: "goal",                 pgType: "user_goal",    swiftModel: "User", swiftProperty: "goal",                swiftType: "UserGoal?"),
+        Column(table: "user", pgColumn: "phase_2_completed_at", pgType: "TIMESTAMPTZ",  swiftModel: "User", swiftProperty: "phase2CompletedAt",   swiftType: "Date?"),
+        Column(table: "user", pgColumn: "beta_tier",            pgType: "beta_tier",    swiftModel: "User", swiftProperty: "betaTier",            swiftType: "BetaTier"),
+        Column(table: "user", pgColumn: "created_at",           pgType: "TIMESTAMPTZ",  swiftModel: "User", swiftProperty: "createdAt",           swiftType: "Date"),
+        Column(table: "user", pgColumn: "updated_at",           pgType: "TIMESTAMPTZ",  swiftModel: "User", swiftProperty: "updatedAt",           swiftType: "Date"),
+
+        // MARK: - exercise
+
+        Column(table: "exercise", pgColumn: "id",                       pgType: "UUID",             swiftModel: "Exercise", swiftProperty: "id",                     swiftType: "UUID"),
+        Column(table: "exercise", pgColumn: "name",                     pgType: "TEXT",             swiftModel: "Exercise", swiftProperty: "name",                   swiftType: "String"),
+        Column(table: "exercise", pgColumn: "category",                 pgType: "exercise_category", swiftModel: "Exercise", swiftProperty: "category",             swiftType: "ExerciseCategory"),
+        Column(table: "exercise", pgColumn: "muscle_group",             pgType: "muscle_group",     swiftModel: "Exercise", swiftProperty: "muscleGroup",            swiftType: "MuscleGroup"),
+        Column(table: "exercise", pgColumn: "secondary_muscle_groups",  pgType: "muscle_group[]",   swiftModel: "Exercise", swiftProperty: "secondaryMuscleGroups",  swiftType: "[MuscleGroup]"),
+        Column(table: "exercise", pgColumn: "equipment",                pgType: "exercise_equipment", swiftModel: "Exercise", swiftProperty: "equipment",           swiftType: "ExerciseEquipment"),
+        Column(table: "exercise", pgColumn: "instructions",             pgType: "TEXT",             swiftModel: "Exercise", swiftProperty: "instructions",           swiftType: "String?"),
+        Column(table: "exercise", pgColumn: "demo_url",                 pgType: "TEXT",             swiftModel: "Exercise", swiftProperty: "demoURL",               swiftType: "String?"),
+        Column(table: "exercise", pgColumn: "is_custom",                pgType: "BOOLEAN",          swiftModel: "Exercise", swiftProperty: "isCustom",              swiftType: "Bool"),
+        Column(table: "exercise", pgColumn: "created_by",               pgType: "UUID",             swiftModel: "Exercise", swiftProperty: "createdBy",             swiftType: "UUID?"),
+        Column(table: "exercise", pgColumn: "created_at",               pgType: "TIMESTAMPTZ",      swiftModel: "Exercise", swiftProperty: "createdAt",             swiftType: "Date"),
+        Column(table: "exercise", pgColumn: "updated_at",               pgType: "TIMESTAMPTZ",      swiftModel: "Exercise", swiftProperty: "updatedAt",             swiftType: "Date"),
+
+        // MARK: - workout
+        // server_received_at is [BE] — omitted intentionally.
+
+        Column(table: "workout", pgColumn: "id",               pgType: "UUID",            swiftModel: "Workout", swiftProperty: "id",              swiftType: "UUID"),
+        Column(table: "workout", pgColumn: "user_id",          pgType: "UUID",            swiftModel: "Workout", swiftProperty: "user",            swiftType: "User?"),
+        Column(table: "workout", pgColumn: "name",             pgType: "TEXT",            swiftModel: "Workout", swiftProperty: "name",            swiftType: "String?"),
+        Column(table: "workout", pgColumn: "notes",            pgType: "TEXT",            swiftModel: "Workout", swiftProperty: "notes",           swiftType: "String?"),
+        Column(table: "workout", pgColumn: "status",           pgType: "workout_status",  swiftModel: "Workout", swiftProperty: "status",          swiftType: "WorkoutStatus"),
+        Column(table: "workout", pgColumn: "type",             pgType: "workout_type",    swiftModel: "Workout", swiftProperty: "type",            swiftType: "WorkoutType"),
+        Column(table: "workout", pgColumn: "format",           pgType: "workout_format",  swiftModel: "Workout", swiftProperty: "format",          swiftType: "WorkoutFormat"),
+        Column(table: "workout", pgColumn: "plan_id",          pgType: "UUID",            swiftModel: "Workout", swiftProperty: "planID",          swiftType: "UUID?"),
+        Column(table: "workout", pgColumn: "started_at",       pgType: "TIMESTAMPTZ",     swiftModel: "Workout", swiftProperty: "startedAt",       swiftType: "Date"),
+        Column(table: "workout", pgColumn: "completed_at",     pgType: "TIMESTAMPTZ",     swiftModel: "Workout", swiftProperty: "completedAt",     swiftType: "Date?"),
+        Column(table: "workout", pgColumn: "duration_seconds", pgType: "INTEGER",         swiftModel: "Workout", swiftProperty: "durationSeconds", swiftType: "Int?"),
+        Column(table: "workout", pgColumn: "location",         pgType: "workout_location", swiftModel: "Workout", swiftProperty: "location",       swiftType: "WorkoutLocation?"),
+        Column(table: "workout", pgColumn: "rating",           pgType: "SMALLINT",        swiftModel: "Workout", swiftProperty: "rating",          swiftType: "Int?"),
+        Column(table: "workout", pgColumn: "created_at",       pgType: "TIMESTAMPTZ",     swiftModel: "Workout", swiftProperty: "createdAt",       swiftType: "Date"),
+        Column(table: "workout", pgColumn: "updated_at",       pgType: "TIMESTAMPTZ",     swiftModel: "Workout", swiftProperty: "updatedAt",       swiftType: "Date"),
+
+        // MARK: - workout_exercise
+
+        Column(table: "workout_exercise", pgColumn: "id",          pgType: "UUID",      swiftModel: "WorkoutExercise", swiftProperty: "id",          swiftType: "UUID"),
+        Column(table: "workout_exercise", pgColumn: "workout_id",  pgType: "UUID",      swiftModel: "WorkoutExercise", swiftProperty: "workout",     swiftType: "Workout?"),
+        Column(table: "workout_exercise", pgColumn: "exercise_id", pgType: "UUID",      swiftModel: "WorkoutExercise", swiftProperty: "exercise",    swiftType: "Exercise?"),
+        Column(table: "workout_exercise", pgColumn: "order_index", pgType: "INTEGER",   swiftModel: "WorkoutExercise", swiftProperty: "orderIndex",  swiftType: "Int"),
+        Column(table: "workout_exercise", pgColumn: "notes",       pgType: "TEXT",      swiftModel: "WorkoutExercise", swiftProperty: "notes",       swiftType: "String?"),
+        Column(table: "workout_exercise", pgColumn: "rest_seconds", pgType: "INTEGER",  swiftModel: "WorkoutExercise", swiftProperty: "restSeconds", swiftType: "Int?"),
+        Column(table: "workout_exercise", pgColumn: "created_at",  pgType: "TIMESTAMPTZ", swiftModel: "WorkoutExercise", swiftProperty: "createdAt", swiftType: "Date"),
+        Column(table: "workout_exercise", pgColumn: "updated_at",  pgType: "TIMESTAMPTZ", swiftModel: "WorkoutExercise", swiftProperty: "updatedAt", swiftType: "Date"),
+
+        // MARK: - workout_set
+        // server_received_at is [BE] — omitted intentionally.
+
+        Column(table: "workout_set", pgColumn: "id",                   pgType: "UUID",           swiftModel: "WorkoutSet", swiftProperty: "id",                  swiftType: "UUID"),
+        Column(table: "workout_set", pgColumn: "workout_exercise_id",  pgType: "UUID",           swiftModel: "WorkoutSet", swiftProperty: "workoutExercise",     swiftType: "WorkoutExercise?"),
+        Column(table: "workout_set", pgColumn: "set_number",           pgType: "INTEGER",        swiftModel: "WorkoutSet", swiftProperty: "setNumber",           swiftType: "Int"),
+        Column(table: "workout_set", pgColumn: "set_type",             pgType: "set_type",       swiftModel: "WorkoutSet", swiftProperty: "setType",             swiftType: "SetType"),
+        Column(table: "workout_set", pgColumn: "weight",               pgType: "NUMERIC",        swiftModel: "WorkoutSet", swiftProperty: "weight",              swiftType: "Double?"),
+        Column(table: "workout_set", pgColumn: "weight_unit",          pgType: "weight_unit",    swiftModel: "WorkoutSet", swiftProperty: "weightUnit",          swiftType: "WeightUnit?"),
+        Column(table: "workout_set", pgColumn: "weight_modifier",      pgType: "weight_modifier", swiftModel: "WorkoutSet", swiftProperty: "weightModifier",    swiftType: "WeightModifier"),
+        Column(table: "workout_set", pgColumn: "modifier_value",       pgType: "NUMERIC",        swiftModel: "WorkoutSet", swiftProperty: "modifierValue",       swiftType: "Double?"),
+        Column(table: "workout_set", pgColumn: "modifier_unit",        pgType: "weight_unit",    swiftModel: "WorkoutSet", swiftProperty: "modifierUnit",        swiftType: "WeightUnit?"),
+        Column(table: "workout_set", pgColumn: "reps",                 pgType: "INTEGER",        swiftModel: "WorkoutSet", swiftProperty: "reps",                swiftType: "Int?"),
+        Column(table: "workout_set", pgColumn: "duration_seconds",     pgType: "INTEGER",        swiftModel: "WorkoutSet", swiftProperty: "durationSeconds",     swiftType: "Int?"),
+        Column(table: "workout_set", pgColumn: "distance_meters",      pgType: "NUMERIC",        swiftModel: "WorkoutSet", swiftProperty: "distanceMeters",      swiftType: "Double?"),
+        Column(table: "workout_set", pgColumn: "calories",             pgType: "INTEGER",        swiftModel: "WorkoutSet", swiftProperty: "calories",            swiftType: "Int?"),
+        Column(table: "workout_set", pgColumn: "rpe",                  pgType: "SMALLINT",       swiftModel: "WorkoutSet", swiftProperty: "rpe",                 swiftType: "Int?"),
+        Column(table: "workout_set", pgColumn: "is_completed",         pgType: "BOOLEAN",        swiftModel: "WorkoutSet", swiftProperty: "isCompleted",         swiftType: "Bool"),
+        Column(table: "workout_set", pgColumn: "notes",                pgType: "TEXT",           swiftModel: "WorkoutSet", swiftProperty: "notes",               swiftType: "String?"),
+        Column(table: "workout_set", pgColumn: "created_at",           pgType: "TIMESTAMPTZ",    swiftModel: "WorkoutSet", swiftProperty: "createdAt",           swiftType: "Date"),
+        Column(table: "workout_set", pgColumn: "updated_at",           pgType: "TIMESTAMPTZ",    swiftModel: "WorkoutSet", swiftProperty: "updatedAt",           swiftType: "Date"),
+
+        // MARK: - personal_record
+
+        Column(table: "personal_record", pgColumn: "id",                   pgType: "UUID",           swiftModel: "PersonalRecord", swiftProperty: "id",                  swiftType: "UUID"),
+        Column(table: "personal_record", pgColumn: "user_id",              pgType: "UUID",           swiftModel: "PersonalRecord", swiftProperty: "user",                swiftType: "User?"),
+        Column(table: "personal_record", pgColumn: "exercise_id",          pgType: "UUID",           swiftModel: "PersonalRecord", swiftProperty: "exercise",            swiftType: "Exercise?"),
+        Column(table: "personal_record", pgColumn: "workout_set_id",       pgType: "UUID",           swiftModel: "PersonalRecord", swiftProperty: "workoutSetID",        swiftType: "UUID"),
+        Column(table: "personal_record", pgColumn: "weight_modifier",      pgType: "weight_modifier", swiftModel: "PersonalRecord", swiftProperty: "weightModifier",    swiftType: "WeightModifier"),
+        Column(table: "personal_record", pgColumn: "record_type",          pgType: "record_type",    swiftModel: "PersonalRecord", swiftProperty: "recordType",          swiftType: "RecordType"),
+        Column(table: "personal_record", pgColumn: "value",                pgType: "NUMERIC",        swiftModel: "PersonalRecord", swiftProperty: "value",               swiftType: "Double"),
+        Column(table: "personal_record", pgColumn: "value_unit",           pgType: "value_unit",     swiftModel: "PersonalRecord", swiftProperty: "valueUnit",           swiftType: "ValueUnit?"),
+        Column(table: "personal_record", pgColumn: "recorded_at",          pgType: "TIMESTAMPTZ",    swiftModel: "PersonalRecord", swiftProperty: "recordedAt",          swiftType: "Date"),
+        Column(table: "personal_record", pgColumn: "previous_value",       pgType: "NUMERIC",        swiftModel: "PersonalRecord", swiftProperty: "previousValue",       swiftType: "Double?"),
+        Column(table: "personal_record", pgColumn: "previous_recorded_at", pgType: "TIMESTAMPTZ",    swiftModel: "PersonalRecord", swiftProperty: "previousRecordedAt",  swiftType: "Date?"),
+        Column(table: "personal_record", pgColumn: "created_at",           pgType: "TIMESTAMPTZ",    swiftModel: "PersonalRecord", swiftProperty: "createdAt",           swiftType: "Date"),
+        Column(table: "personal_record", pgColumn: "updated_at",           pgType: "TIMESTAMPTZ",    swiftModel: "PersonalRecord", swiftProperty: "updatedAt",           swiftType: "Date"),
+
+        // MARK: - job
+        // user_id, created_at, started_at, completed_at are [BE] — omitted intentionally.
+
+        Column(table: "job", pgColumn: "id",            pgType: "UUID",       swiftModel: "Job", swiftProperty: "id",           swiftType: "UUID"),
+        Column(table: "job", pgColumn: "job_type",      pgType: "job_type",   swiftModel: "Job", swiftProperty: "jobType",      swiftType: "JobType"),
+        Column(table: "job", pgColumn: "status",        pgType: "job_status", swiftModel: "Job", swiftProperty: "status",       swiftType: "JobStatus"),
+        Column(table: "job", pgColumn: "result",        pgType: "JSONB",      swiftModel: "Job", swiftProperty: "result",       swiftType: "String?"),
+        Column(table: "job", pgColumn: "error_message", pgType: "TEXT",       swiftModel: "Job", swiftProperty: "errorMessage", swiftType: "String?"),
+        Column(table: "job", pgColumn: "expires_at",    pgType: "TIMESTAMPTZ", swiftModel: "Job", swiftProperty: "expiresAt",   swiftType: "Date"),
+
+        // MARK: - sync_event_log
+
+        Column(table: "sync_event_log", pgColumn: "id",          pgType: "UUID",             swiftModel: "SyncEventLog", swiftProperty: "id",          swiftType: "UUID"),
+        Column(table: "sync_event_log", pgColumn: "user_id",     pgType: "UUID",             swiftModel: "SyncEventLog", swiftProperty: "user",        swiftType: "User?"),
+        Column(table: "sync_event_log", pgColumn: "event_type",  pgType: "sync_event_type",  swiftModel: "SyncEventLog", swiftProperty: "eventType",   swiftType: "SyncEventType"),
+        Column(table: "sync_event_log", pgColumn: "entity_type", pgType: "sync_entity_type", swiftModel: "SyncEventLog", swiftProperty: "entityType",  swiftType: "SyncEntityType"),
+        Column(table: "sync_event_log", pgColumn: "entity_id",   pgType: "UUID",             swiftModel: "SyncEventLog", swiftProperty: "entityID",    swiftType: "UUID"),
+        Column(table: "sync_event_log", pgColumn: "detail",      pgType: "TEXT",             swiftModel: "SyncEventLog", swiftProperty: "detail",      swiftType: "String?"),
+        Column(table: "sync_event_log", pgColumn: "occurred_at", pgType: "TIMESTAMPTZ",      swiftModel: "SyncEventLog", swiftProperty: "occurredAt",  swiftType: "Date"),
+        Column(table: "sync_event_log", pgColumn: "uploaded_at", pgType: "TIMESTAMPTZ",      swiftModel: "SyncEventLog", swiftProperty: "uploadedAt",  swiftType: "Date?"),
+
+        // MARK: - support_report
+        // created_at is [BE] — omitted intentionally.
+
+        Column(table: "support_report", pgColumn: "id",                pgType: "UUID",      swiftModel: "SupportReport", swiftProperty: "id",               swiftType: "UUID"),
+        Column(table: "support_report", pgColumn: "user_id",           pgType: "UUID",      swiftModel: "SupportReport", swiftProperty: "user",             swiftType: "User?"),
+        Column(table: "support_report", pgColumn: "device_model",      pgType: "TEXT",      swiftModel: "SupportReport", swiftProperty: "deviceModel",      swiftType: "String"),
+        Column(table: "support_report", pgColumn: "ios_version",       pgType: "TEXT",      swiftModel: "SupportReport", swiftProperty: "iosVersion",       swiftType: "String"),
+        Column(table: "support_report", pgColumn: "app_version",       pgType: "TEXT",      swiftModel: "SupportReport", swiftProperty: "appVersion",       swiftType: "String"),
+        // 'description' is reserved by @Model (CustomStringConvertible) — mapped to reportDescription.
+        Column(table: "support_report", pgColumn: "description",       pgType: "TEXT",      swiftModel: "SupportReport", swiftProperty: "reportDescription", swiftType: "String"),
+        Column(table: "support_report", pgColumn: "sync_log_uploaded", pgType: "BOOLEAN",   swiftModel: "SupportReport", swiftProperty: "syncLogUploaded",  swiftType: "Bool"),
+    ]
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/SupportReport.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/SupportReport.swift
@@ -1,0 +1,32 @@
+import Foundation
+import SwiftData
+
+@Model
+public final class SupportReport {
+    public var id: UUID
+    public var deviceModel: String
+    public var iosVersion: String
+    public var appVersion: String
+    // Mapped from pg column 'description' — renamed because @Model synthesises
+    // CustomStringConvertible and reserves that property name.
+    public var reportDescription: String
+    public var syncLogUploaded: Bool
+
+    public var user: User?
+
+    public init(
+        id: UUID = UUID(),
+        deviceModel: String,
+        iosVersion: String,
+        appVersion: String,
+        reportDescription: String,
+        syncLogUploaded: Bool = false
+    ) {
+        self.id = id
+        self.deviceModel = deviceModel
+        self.iosVersion = iosVersion
+        self.appVersion = appVersion
+        self.reportDescription = reportDescription
+        self.syncLogUploaded = syncLogUploaded
+    }
+}

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/User.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/User.swift
@@ -29,6 +29,9 @@ public final class User {
     @Relationship(deleteRule: .cascade, inverse: \SyncEventLog.user)
     public var syncEventLogs: [SyncEventLog]
 
+    @Relationship(deleteRule: .cascade, inverse: \SupportReport.user)
+    public var supportReports: [SupportReport]
+
     public init(
         id: UUID = UUID(),
         email: String? = nil,
@@ -61,5 +64,6 @@ public final class User {
         self.personalRecords = []
         self.jobs = []
         self.syncEventLogs = []
+        self.supportReports = []
     }
 }

--- a/PRLiftsCore/Sources/PRLiftsCore/Models/Workout.swift
+++ b/PRLiftsCore/Sources/PRLiftsCore/Models/Workout.swift
@@ -9,6 +9,8 @@ public final class Workout {
     public var status: WorkoutStatus
     public var type: WorkoutType
     public var format: WorkoutFormat
+    // V2: will reference WorkoutPlan when the plan model is introduced.
+    public var planID: UUID?
     public var startedAt: Date
     public var completedAt: Date?
     public var durationSeconds: Int?
@@ -30,6 +32,7 @@ public final class Workout {
         status: WorkoutStatus = .inProgress,
         type: WorkoutType,
         format: WorkoutFormat,
+        planID: UUID? = nil,
         startedAt: Date = Date(),
         completedAt: Date? = nil,
         durationSeconds: Int? = nil,
@@ -45,6 +48,7 @@ public final class Workout {
         self.status = status
         self.type = type
         self.format = format
+        self.planID = planID
         self.startedAt = startedAt
         self.completedAt = completedAt
         self.durationSeconds = durationSeconds

--- a/PRLiftsCore/Sources/PRLiftsCoreTestSupport/ModelStubs.swift
+++ b/PRLiftsCore/Sources/PRLiftsCoreTestSupport/ModelStubs.swift
@@ -164,6 +164,26 @@ public extension SyncEventLog {
     }
 }
 
+public extension SupportReport {
+    static func stub(
+        id: UUID = UUID(),
+        deviceModel: String = "iPhone SE (3rd generation)",
+        iosVersion: String = "18.0",
+        appVersion: String = "1.0.0",
+        reportDescription: String = "App crashed on workout screen",
+        syncLogUploaded: Bool = false
+    ) -> SupportReport {
+        SupportReport(
+            id: id,
+            deviceModel: deviceModel,
+            iosVersion: iosVersion,
+            appVersion: appVersion,
+            reportDescription: reportDescription,
+            syncLogUploaded: syncLogUploaded
+        )
+    }
+}
+
 public enum TestContainerFactory {
     public static func make() throws -> ModelContainer {
         let schema = Schema(PRLiftsSchema.models)

--- a/PRLiftsCore/Tests/PRLiftsCoreTests/Models/SupportReportModelTests.swift
+++ b/PRLiftsCore/Tests/PRLiftsCoreTests/Models/SupportReportModelTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+@testable import PRLiftsCore
+import PRLiftsCoreTestSupport
+import SwiftData
+import XCTest
+
+@MainActor
+final class SupportReportModelTests: XCTestCase {
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestContainerFactory.make()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        context = nil
+        container = nil
+    }
+
+    func testDefaultSyncLogUploaded() throws {
+        let report = SupportReport(
+            deviceModel: "iPhone 16",
+            iosVersion: "18.0",
+            appVersion: "1.0.0",
+            reportDescription: "Test issue"
+        )
+        context.insert(report)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SupportReport>())
+        XCTAssertFalse(try XCTUnwrap(fetched.first).syncLogUploaded)
+    }
+
+    func testFieldsPersist() throws {
+        let report = SupportReport.stub()
+        context.insert(report)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SupportReport>())
+        let result = try XCTUnwrap(fetched.first)
+
+        XCTAssertEqual(result.deviceModel, "iPhone SE (3rd generation)")
+        XCTAssertEqual(result.iosVersion, "18.0")
+        XCTAssertEqual(result.appVersion, "1.0.0")
+        XCTAssertEqual(result.reportDescription, "App crashed on workout screen")
+        XCTAssertFalse(result.syncLogUploaded)
+    }
+
+    func testSyncLogUploadedToggle() throws {
+        let report = SupportReport.stub(syncLogUploaded: true)
+        context.insert(report)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<SupportReport>())
+        XCTAssertTrue(try XCTUnwrap(fetched.first).syncLogUploaded)
+    }
+
+    func testUserRelationship() throws {
+        let user = User.stub()
+        let report = SupportReport.stub()
+        context.insert(user)
+        context.insert(report)
+        user.supportReports.append(report)
+        try context.save()
+
+        let fetchedUsers = try context.fetch(FetchDescriptor<User>())
+        let result = try XCTUnwrap(fetchedUsers.first)
+
+        XCTAssertEqual(result.supportReports.count, 1)
+        XCTAssertEqual(result.supportReports.first?.deviceModel, "iPhone SE (3rd generation)")
+    }
+
+    func testCascadeDeleteOnUserDelete() throws {
+        let user = User.stub()
+        let report = SupportReport.stub()
+        context.insert(user)
+        context.insert(report)
+        user.supportReports.append(report)
+        try context.save()
+
+        context.delete(user)
+        try context.save()
+
+        let reports = try context.fetch(FetchDescriptor<SupportReport>())
+        XCTAssertTrue(reports.isEmpty)
+    }
+}

--- a/backend/scripts/validate_schema_mapping.py
+++ b/backend/scripts/validate_schema_mapping.py
@@ -1,0 +1,161 @@
+"""
+validate_schema_mapping.py
+PRLifts Backend
+
+Parses docs/SCHEMA.md [iOS]/[BE] column annotations and validates the
+declarative mapping in PRLiftsCore/Sources/PRLiftsCore/Models/SchemaMapping.swift.
+
+Imported by tests/test_schema_mapping.py — not a standalone script.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCHEMA_MD_PATH = REPO_ROOT / "docs" / "SCHEMA.md"
+SCHEMA_MAPPING_SWIFT_PATH = (
+    REPO_ROOT
+    / "PRLiftsCore"
+    / "Sources"
+    / "PRLiftsCore"
+    / "Models"
+    / "SchemaMapping.swift"
+)
+
+_SQL_CONSTRAINT_KEYWORDS = frozenset(
+    {"CONSTRAINT", "CHECK", "UNIQUE", "PRIMARY", "FOREIGN", "INDEX", "KEY"}
+)
+
+# Standard PostgreSQL type -> accepted Swift types.
+# UUID may also map to a SwiftData relationship (checked separately).
+_PG_SWIFT_COMPAT: dict[str, frozenset[str]] = {
+    "UUID": frozenset({"UUID", "UUID?"}),
+    "TEXT": frozenset({"String", "String?"}),
+    "BOOLEAN": frozenset({"Bool", "Bool?"}),
+    "INTEGER": frozenset({"Int", "Int?"}),
+    "SMALLINT": frozenset({"Int", "Int?"}),
+    "NUMERIC": frozenset({"Double", "Double?", "Decimal", "Decimal?"}),
+    "TIMESTAMPTZ": frozenset({"Date", "Date?"}),
+    "DATE": frozenset({"Date", "Date?"}),
+    "JSONB": frozenset({"String", "String?", "Data", "Data?"}),
+}
+
+
+class ColumnInfo(NamedTuple):
+    table: str
+    pg_column: str
+    pg_type: str
+    annotation: str  # 'iOS' or 'BE'
+
+
+class MappingEntry(NamedTuple):
+    table: str
+    pg_column: str
+    pg_type: str
+    swift_model: str
+    swift_property: str
+    swift_type: str
+
+
+def _normalize_pg_type(raw: str) -> str:
+    """Strip NUMERIC(n,m) params; uppercase standard types; preserve enums/arrays."""
+    base = re.sub(r"\(.*?\)", "", raw).strip().rstrip(",")
+    return base.upper() if base.upper() in _PG_SWIFT_COMPAT else base
+
+
+def parse_schema_md(
+    path: Path = SCHEMA_MD_PATH,
+) -> tuple[list[ColumnInfo], list[tuple[str, str]]]:
+    """
+    Parse SCHEMA.md and return annotated columns and unannotated column names.
+
+    Returns:
+        annotated: all columns carrying an [iOS] or [BE] annotation.
+        unannotated: (table, column) pairs that lack any annotation.
+    """
+    content = path.read_text(encoding="utf-8")
+    sql_blocks = re.findall(r"```sql\n(.*?)```", content, re.DOTALL)
+
+    annotated: list[ColumnInfo] = []
+    unannotated: list[tuple[str, str]] = []
+
+    table_re = re.compile(r'CREATE TABLE\s+"?(\w+)"?\s*\((.*?)\);', re.DOTALL)
+
+    for block in sql_blocks:
+        for table_match in table_re.finditer(block):
+            table_name = table_match.group(1)
+            body = table_match.group(2)
+
+            depth = 0
+            for line in body.splitlines():
+                # Lines at depth > 0 are inside a CONSTRAINT body — not column defs.
+                if depth > 0:
+                    depth += line.count("(") - line.count(")")
+                    continue
+
+                col_match = re.match(r"^\s+(\w+)\s+(\S+)", line)
+                if not col_match:
+                    continue
+                col_name = col_match.group(1)
+                if col_name.upper() in _SQL_CONSTRAINT_KEYWORDS:
+                    # Track paren depth so subsequent lines inside the constraint
+                    # body (e.g. multi-line CHECK) are skipped.
+                    depth += line.count("(") - line.count(")")
+                    continue
+
+                raw_type = col_match.group(2).rstrip(",")
+                pg_type = _normalize_pg_type(raw_type)
+                ann_match = re.search(r"--\s*\[(iOS|BE)\]", line)
+                if ann_match:
+                    annotated.append(
+                        ColumnInfo(table_name, col_name, pg_type, ann_match.group(1))
+                    )
+                else:
+                    unannotated.append((table_name, col_name))
+
+    return annotated, unannotated
+
+
+def parse_schema_mapping_swift(
+    path: Path = SCHEMA_MAPPING_SWIFT_PATH,
+) -> list[MappingEntry]:
+    """Parse SchemaMapping.swift and return all declared Column mapping entries."""
+    content = path.read_text(encoding="utf-8")
+    pattern = re.compile(
+        r'Column\(\s*table:\s*"([^"]+)",\s*pgColumn:\s*"([^"]+)",\s*'
+        r'pgType:\s*"([^"]+)",\s*swiftModel:\s*"([^"]+)",\s*'
+        r'swiftProperty:\s*"([^"]+)",\s*swiftType:\s*"([^"]+)"\s*\)',
+        re.DOTALL,
+    )
+    return [
+        MappingEntry(
+            m.group(1), m.group(2), m.group(3), m.group(4), m.group(5), m.group(6)
+        )
+        for m in pattern.finditer(content)
+    ]
+
+
+def is_lower_camel_case(name: str) -> bool:
+    """Return True if name is a valid lowerCamelCase Swift property name."""
+    return bool(name) and not name[0].isupper() and "_" not in name
+
+
+def is_type_compatible(pg_type: str, swift_type: str) -> bool:
+    """Return True if swift_type is a valid Swift representation of pg_type."""
+    # Array columns: pg ends with '[]', Swift must be an array literal '[...]'
+    if pg_type.endswith("[]"):
+        return swift_type.startswith("[")
+    # Standard PostgreSQL types
+    if pg_type in _PG_SWIFT_COMPAT:
+        if swift_type in _PG_SWIFT_COMPAT[pg_type]:
+            return True
+        # UUID FK columns may map to SwiftData relationships (e.g. User?, Workout?)
+        if pg_type == "UUID":
+            base = swift_type.rstrip("?")
+            return bool(re.match(r"^[A-Z][A-Za-z0-9]+$", base))
+        return False
+    # PostgreSQL enum types and other unknown types — accept any non-empty Swift type
+    return bool(swift_type)

--- a/backend/tests/test_schema_mapping.py
+++ b/backend/tests/test_schema_mapping.py
@@ -1,0 +1,115 @@
+"""
+test_schema_mapping.py
+PRLifts Backend Tests
+
+Schema consistency CI tests. Validates that SchemaMapping.swift in PRLiftsCore
+accurately mirrors the [iOS]/[BE] annotations declared in docs/SCHEMA.md.
+
+Five test cases enforced:
+  1. Every [iOS]-annotated column has a mapping entry in SchemaMapping.swift.
+  2. Every swiftProperty in SchemaMapping.swift is lowerCamelCase.
+  3. Every swiftType in SchemaMapping.swift is compatible with the PostgreSQL type.
+  4. No [BE]-annotated column appears in SchemaMapping.swift.
+  5. Every column in SCHEMA.md carries an [iOS] or [BE] annotation.
+"""
+
+import pytest
+
+from scripts.validate_schema_mapping import (
+    ColumnInfo,
+    MappingEntry,
+    is_lower_camel_case,
+    is_type_compatible,
+    parse_schema_mapping_swift,
+    parse_schema_md,
+)
+
+
+@pytest.fixture(scope="module")
+def schema_data() -> tuple[list[ColumnInfo], list[tuple[str, str]]]:
+    return parse_schema_md()
+
+
+@pytest.fixture(scope="module")
+def mapping_entries() -> list[MappingEntry]:
+    return parse_schema_mapping_swift()
+
+
+def test_all_ios_columns_have_mapping(
+    schema_data: tuple[list[ColumnInfo], list[tuple[str, str]]],
+    mapping_entries: list[MappingEntry],
+) -> None:
+    """Every [iOS]-annotated column in SCHEMA.md must appear in SchemaMapping.swift."""
+    annotated, _ = schema_data
+    ios_pairs = {(c.table, c.pg_column) for c in annotated if c.annotation == "iOS"}
+    mapped_pairs = {(e.table, e.pg_column) for e in mapping_entries}
+    missing = ios_pairs - mapped_pairs
+    assert not missing, "[iOS] columns missing from SchemaMapping.swift:\n" + "\n".join(
+        f"  {t}.{c}" for t, c in sorted(missing)
+    )
+
+
+def test_swift_property_names_are_camel_case(
+    mapping_entries: list[MappingEntry],
+) -> None:
+    """Every swiftProperty in SchemaMapping.swift must be lowerCamelCase."""
+    violations = [
+        (e.table, e.pg_column, e.swift_property)
+        for e in mapping_entries
+        if not is_lower_camel_case(e.swift_property)
+    ]
+    assert not violations, (
+        "swiftProperty names that are not lowerCamelCase:\n"
+        + "\n".join(f"  {t}.{p} -> '{s}'" for t, p, s in violations)
+    )
+
+
+def test_swift_types_are_compatible(
+    schema_data: tuple[list[ColumnInfo], list[tuple[str, str]]],
+    mapping_entries: list[MappingEntry],
+) -> None:
+    """Every swiftType in SchemaMapping.swift must be compatible with its pg type."""
+    annotated, _ = schema_data
+    pg_type_for = {(c.table, c.pg_column): c.pg_type for c in annotated}
+
+    def _entry_pg_type(e: MappingEntry) -> str:
+        return pg_type_for.get((e.table, e.pg_column), e.pg_type)
+
+    violations = [
+        (e.table, e.pg_column, _entry_pg_type(e), e.swift_type)
+        for e in mapping_entries
+        if not is_type_compatible(_entry_pg_type(e), e.swift_type)
+    ]
+    assert not violations, (
+        "Type incompatibilities in SchemaMapping.swift:\n"
+        + "\n".join(
+            f"  {t}.{c}: pg={pt!r} incompatible with swift={st!r}"
+            for t, c, pt, st in violations
+        )
+    )
+
+
+def test_no_be_columns_in_mapping(
+    schema_data: tuple[list[ColumnInfo], list[tuple[str, str]]],
+    mapping_entries: list[MappingEntry],
+) -> None:
+    """No [BE]-annotated column from SCHEMA.md may appear in SchemaMapping.swift."""
+    annotated, _ = schema_data
+    be_pairs = {(c.table, c.pg_column) for c in annotated if c.annotation == "BE"}
+    mapped_pairs = {(e.table, e.pg_column) for e in mapping_entries}
+    violations = be_pairs & mapped_pairs
+    assert not violations, (
+        "[BE] columns that must not appear in SchemaMapping.swift:\n"
+        + "\n".join(f"  {t}.{c}" for t, c in sorted(violations))
+    )
+
+
+def test_all_columns_are_annotated(
+    schema_data: tuple[list[ColumnInfo], list[tuple[str, str]]],
+) -> None:
+    """Every column in SCHEMA.md must carry an [iOS] or [BE] annotation."""
+    _, unannotated = schema_data
+    assert not unannotated, (
+        "Columns in SCHEMA.md without [iOS] or [BE] annotation:\n"
+        + "\n".join(f"  {t}.{c}" for t, c in unannotated)
+    )


### PR DESCRIPTION
## Summary

- Adds `backend/scripts/validate_schema_mapping.py` — parses `[iOS]`/`[BE]` column annotations in `docs/SCHEMA.md` and validates the declarative mapping in `SchemaMapping.swift`. Handles multi-line `CONSTRAINT` bodies via parenthesis-depth tracking.
- Adds `backend/tests/test_schema_mapping.py` — 5 pytest test cases per STANDARDS.md §5.6, running automatically as part of `backend-ci` (no workflow changes needed).
- Adds `PRLiftsCore/Sources/PRLiftsCore/Models/SchemaMapping.swift` — declarative registry mapping every `[iOS]`-annotated PostgreSQL column to its SwiftData model, property name, and type. `[BE]` columns are explicitly excluded.
- Adds `PRLiftsCore/Sources/PRLiftsCore/Models/SupportReport.swift` — missing SwiftData model for the `support_report` table (`description` renamed to `reportDescription` to avoid `@Model` macro conflict, documented with a comment per STANDARDS.md §5.6).
- Adds `PRLiftsCore/Tests/PRLiftsCoreTests/Models/SupportReportModelTests.swift` — 5 tests covering the new model including cascade delete behaviour.
- Updates `Workout.swift` — adds `planID: UUID?` (`plan_id` was `[iOS]`-annotated in SCHEMA.md but absent from the model).
- Updates `User.swift` — adds `supportReports: [SupportReport]` cascade relationship.
- Updates `PRLiftsSchema.swift` and `ModelStubs.swift` to include `SupportReport`.

Closes #49, closes #50.

## Test plan

- [ ] `pytest` in `backend/` — all 307 tests pass (including 5 new schema tests), 97.48% coverage
- [ ] `ruff check .` and `ruff format --check .` — clean
- [ ] `mypy` — no issues
- [ ] Pre-commit hook passed — Xcode build + UI tests on iPhone SE (3rd generation) all green
- [ ] Verify CI fails correctly: add an unannotated column or a `[BE]` column to `SchemaMapping.swift` and confirm the relevant test fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)