### PR TITLE
Add PRLifts shared scheme with CI and weekly test plans

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -20,6 +20,7 @@ if [ -n "$STAGED_SWIFT" ]; then
   xcodebuild test \
     -project "$REPO_ROOT/PRLifts/PRLifts.xcodeproj" \
     -scheme PRLifts \
+    -testPlan PRLiftsWeeklyTests \
     -destination 'platform=iOS Simulator,id=6C107B89-D600-4A9E-81BA-3606168CD8A3' \
     -quiet 2>&1
   TEST_STATUS=$?

--- a/PRLifts/PRLifts.xcodeproj/xcshareddata/xcschemes/PRLifts.xcscheme
+++ b/PRLifts/PRLifts.xcodeproj/xcshareddata/xcschemes/PRLifts.xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A47327812FA066AD009B2BC7"
+               BuildableName = "PRLifts.app"
+               BlueprintName = "PRLifts"
+               ReferencedContainer = "container:PRLifts.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "NO">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:PRLiftsCITests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:PRLiftsWeeklyTests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A473278E2FA066AE009B2BC7"
+               BuildableName = "PRLiftsTests.xctest"
+               BlueprintName = "PRLiftsTests"
+               ReferencedContainer = "container:PRLifts.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A47327982FA066AE009B2BC7"
+               BuildableName = "PRLiftsUITests.xctest"
+               BlueprintName = "PRLiftsUITests"
+               ReferencedContainer = "container:PRLifts.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A47327812FA066AD009B2BC7"
+            BuildableName = "PRLifts.app"
+            BlueprintName = "PRLifts"
+            ReferencedContainer = "container:PRLifts.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A47327812FA066AD009B2BC7"
+            BuildableName = "PRLifts.app"
+            BlueprintName = "PRLifts"
+            ReferencedContainer = "container:PRLifts.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary

- Creates `PRLifts/PRLifts.xcodeproj/xcshareddata/xcschemes/PRLifts.xcscheme` — the shared scheme Xcode Cloud uses to discover test plans
- Registers `PRLiftsCITests.xctestplan` as the **default** test plan (unit tests only, used by every PR/push CI build)
- Registers `PRLiftsWeeklyTests.xctestplan` as the secondary test plan (full suite including UI tests, used by the weekly scheduled build)
- Updates `.githooks/pre-commit` to pass `-testPlan PRLiftsWeeklyTests` explicitly so local pre-commit runs continue executing the full suite (unit + UI), not just the scheme default

## Why

Without a shared scheme file, Xcode Cloud cannot resolve the test plan references added in PR #67. The scheme is the bridge between the `.xctestplan` files committed to the repo and the Xcode Cloud workflow configuration in App Store Connect.

The pre-commit hook fix prevents a silent regression: once a scheme has a default test plan, `xcodebuild test -scheme PRLifts` (no `-testPlan` flag) runs only the default (CI-only, unit tests). Pinning to `PRLiftsWeeklyTests` in the hook preserves the full local gate.

## Test plan

- [ ] Open PRLifts.xcodeproj in Xcode and confirm the scheme editor shows both test plans under the Test action, with PRLiftsCITests marked as default
- [ ] Confirm `xcodebuild test -scheme PRLifts -testPlan PRLiftsCITests` builds and runs unit tests only (no UI test targets)
- [ ] Confirm `xcodebuild test -scheme PRLifts -testPlan PRLiftsWeeklyTests` runs both PRLiftsTests and PRLiftsUITests
- [ ] Confirm pre-commit hook still passes on a Swift file commit (runs full weekly suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)