### PR TITLE
P1-08 — WorkoutScreen active workout logging UI

### DIFF
--- a/PRLifts/PRLifts/Home/HomeScreen.swift
+++ b/PRLifts/PRLifts/Home/HomeScreen.swift
@@ -1,7 +1,8 @@
 import SwiftUI
+import PRLiftsCore
 
 struct HomeScreen: View {
-    @State private var showComingSoon = false
+    @State private var activeWorkout: Workout?
     private let streak = 0
 
     var body: some View {
@@ -21,11 +22,13 @@ struct HomeScreen: View {
                 .padding(.bottom, PRSpacing.large)
             }
         }
-        .alert("Coming Soon", isPresented: $showComingSoon) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text("Workout logging is coming soon.")
+        .sheet(item: $activeWorkout) { workout in
+            WorkoutScreen(workout: workout) {
+                activeWorkout = nil
+            }
+            .interactiveDismissDisabled()
         }
+        .accessibilityIdentifier("HomeScreen")
     }
 
     // MARK: Header
@@ -101,7 +104,7 @@ struct HomeScreen: View {
 
     private var startWorkoutButton: some View {
         PRButton(label: "Start Workout", icon: "plus") {
-            showComingSoon = true
+            activeWorkout = Workout(type: .adHoc, format: .weightlifting)
         }
     }
 

--- a/PRLifts/PRLifts/Workout/ExercisePickerSheet.swift
+++ b/PRLifts/PRLifts/Workout/ExercisePickerSheet.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+import SwiftData
+import PRLiftsCore
+
+struct ExercisePickerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Query(sort: \Exercise.name) private var localExercises: [Exercise]
+
+    @State private var searchText = ""
+    @State private var remoteResults: [ExerciseSearchResult] = []
+    @State private var isSearchingRemote = false
+    @State private var remoteTask: Task<Void, Never>? = nil
+
+    let onSelect: (Exercise) -> Void
+    private let exerciseService: any ExerciseServiceProtocol
+
+    init(
+        onSelect: @escaping (Exercise) -> Void,
+        exerciseService: any ExerciseServiceProtocol = StubExerciseService()
+    ) {
+        self.onSelect = onSelect
+        self.exerciseService = exerciseService
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.prBackground.ignoresSafeArea()
+                exerciseList
+            }
+            .navigationTitle("Add Exercise")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(.prBrandLight)
+                }
+            }
+            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search exercises")
+            .onChange(of: searchText) { _, query in
+                scheduleRemoteSearch(query: query)
+            }
+        }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+        .presentationBackground(Color.prBackgroundSec)
+    }
+
+    // MARK: List
+
+    private var exerciseList: some View {
+        let filtered = filteredLocal
+        return Group {
+            if filtered.isEmpty && searchText.isEmpty {
+                emptyLocalState
+            } else {
+                List {
+                    if !filtered.isEmpty {
+                        Section("Local library") {
+                            ForEach(filtered) { exercise in
+                                exerciseRow(exercise)
+                            }
+                        }
+                    }
+                    if !remoteResults.isEmpty {
+                        Section("Search results") {
+                            ForEach(remoteResults) { result in
+                                remoteResultRow(result)
+                            }
+                        }
+                    }
+                    if isSearchingRemote {
+                        Section {
+                            HStack {
+                                Spacer()
+                                ProgressView()
+                                Spacer()
+                            }
+                        }
+                    }
+                }
+                .listStyle(.insetGrouped)
+                .scrollContentBackground(.hidden)
+            }
+        }
+    }
+
+    private var filteredLocal: [Exercise] {
+        guard !searchText.isEmpty else { return localExercises }
+        return localExercises.filter {
+            $0.name.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    private var emptyLocalState: some View {
+        VStack(spacing: PRSpacing.medium) {
+            Image(systemName: "dumbbell")
+                .font(.system(size: 40))
+                .foregroundColor(.prTextTertiary)
+                .accessibilityHidden(true)
+            Text("No exercises yet")
+                .font(.prHeadlineMedium)
+                .foregroundColor(.prTextPrimary)
+            Text("Search to find exercises from the library.")
+                .font(.prBodySecondary)
+                .foregroundColor(.prTextSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, PRSpacing.large)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: Rows
+
+    private func exerciseRow(_ exercise: Exercise) -> some View {
+        Button {
+            onSelect(exercise)
+            dismiss()
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: PRSpacing.xxxSmall) {
+                    Text(exercise.name)
+                        .font(.prBody)
+                        .foregroundColor(.prTextPrimary)
+                    Text("\(exercise.muscleGroup.displayName) · \(exercise.equipment.displayName)")
+                        .font(.prCaption)
+                        .foregroundColor(.prTextSecondary)
+                }
+                Spacer()
+                Image(systemName: "plus.circle")
+                    .foregroundColor(.prBrand)
+                    .accessibilityHidden(true)
+            }
+        }
+        .accessibilityLabel("\(exercise.name), \(exercise.muscleGroup.displayName)")
+        .accessibilityHint("Double-tap to add")
+    }
+
+    private func remoteResultRow(_ result: ExerciseSearchResult) -> some View {
+        Button {
+            let exercise = Exercise(
+                id: result.id,
+                name: result.name,
+                category: result.category,
+                muscleGroup: result.muscleGroup,
+                secondaryMuscleGroups: [],
+                equipment: result.equipment
+            )
+            onSelect(exercise)
+            dismiss()
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: PRSpacing.xxxSmall) {
+                    Text(result.name)
+                        .font(.prBody)
+                        .foregroundColor(.prTextPrimary)
+                    Text("\(result.muscleGroup.displayName) · \(result.equipment.displayName)")
+                        .font(.prCaption)
+                        .foregroundColor(.prTextSecondary)
+                }
+                Spacer()
+                Image(systemName: "plus.circle")
+                    .foregroundColor(.prBrand)
+                    .accessibilityHidden(true)
+            }
+        }
+        .accessibilityLabel("\(result.name), \(result.muscleGroup.displayName)")
+        .accessibilityHint("Double-tap to add")
+    }
+
+    // MARK: Remote search
+
+    private func scheduleRemoteSearch(query: String) {
+        remoteTask?.cancel()
+        remoteResults = []
+        guard !query.isEmpty else {
+            isSearchingRemote = false
+            return
+        }
+        guard filteredLocal.isEmpty else { return }
+
+        isSearchingRemote = true
+        remoteTask = Task {
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled else { return }
+            if let results = try? await exerciseService.search(query: query) {
+                remoteResults = results
+            }
+            isSearchingRemote = false
+        }
+    }
+}
+
+// MARK: Display helpers
+
+private extension MuscleGroup {
+    var displayName: String {
+        switch self {
+        case .upperChest:   return "Upper chest"
+        case .midChest:     return "Mid chest"
+        case .lowerChest:   return "Lower chest"
+        case .upperBack:    return "Upper back"
+        case .lowerBack:    return "Lower back"
+        case .shoulders:    return "Shoulders"
+        case .biceps:       return "Biceps"
+        case .triceps:      return "Triceps"
+        case .quads:        return "Quads"
+        case .hamstrings:   return "Hamstrings"
+        case .calves:       return "Calves"
+        case .glutes:       return "Glutes"
+        case .abs:          return "Abs"
+        case .obliques:     return "Obliques"
+        case .fullBody:     return "Full body"
+        }
+    }
+}
+
+private extension ExerciseEquipment {
+    var displayName: String {
+        switch self {
+        case .barbell:        return "Barbell"
+        case .dumbbell:       return "Dumbbell"
+        case .kettlebell:     return "Kettlebell"
+        case .machine:        return "Machine"
+        case .cable:          return "Cable"
+        case .bodyweight:     return "Bodyweight"
+        case .cardioMachine:  return "Cardio machine"
+        case .other:          return "Other"
+        }
+    }
+}

--- a/PRLifts/PRLifts/Workout/ExerciseServiceProtocol.swift
+++ b/PRLifts/PRLifts/Workout/ExerciseServiceProtocol.swift
@@ -1,0 +1,35 @@
+import Foundation
+import PRLiftsCore
+
+struct ExerciseSearchResult: Identifiable, Sendable {
+    let id: UUID
+    let name: String
+    let category: ExerciseCategory
+    let muscleGroup: MuscleGroup
+    let equipment: ExerciseEquipment
+}
+
+protocol ExerciseServiceProtocol: Sendable {
+    func search(query: String) async throws -> [ExerciseSearchResult]
+}
+
+final class StubExerciseService: ExerciseServiceProtocol {
+    nonisolated init() {}
+
+    func search(query: String) async throws -> [ExerciseSearchResult] {
+        try await Task.sleep(for: .milliseconds(300))
+        let q = query.lowercased()
+        return _catalog.filter { $0.name.lowercased().contains(q) }
+    }
+
+    private let _catalog: [ExerciseSearchResult] = [
+        ExerciseSearchResult(id: UUID(), name: "Bench Press", category: .strength, muscleGroup: .midChest, equipment: .barbell),
+        ExerciseSearchResult(id: UUID(), name: "Squat", category: .strength, muscleGroup: .quads, equipment: .barbell),
+        ExerciseSearchResult(id: UUID(), name: "Deadlift", category: .strength, muscleGroup: .lowerBack, equipment: .barbell),
+        ExerciseSearchResult(id: UUID(), name: "Pull-Up", category: .strength, muscleGroup: .upperBack, equipment: .bodyweight),
+        ExerciseSearchResult(id: UUID(), name: "Overhead Press", category: .strength, muscleGroup: .shoulders, equipment: .barbell),
+        ExerciseSearchResult(id: UUID(), name: "Barbell Row", category: .strength, muscleGroup: .upperBack, equipment: .barbell),
+        ExerciseSearchResult(id: UUID(), name: "Dumbbell Curl", category: .strength, muscleGroup: .biceps, equipment: .dumbbell),
+        ExerciseSearchResult(id: UUID(), name: "Tricep Pushdown", category: .strength, muscleGroup: .triceps, equipment: .cable),
+    ]
+}

--- a/PRLifts/PRLifts/Workout/WorkoutScreen.swift
+++ b/PRLifts/PRLifts/Workout/WorkoutScreen.swift
@@ -1,0 +1,359 @@
+import SwiftUI
+import SwiftData
+import PRLiftsCore
+
+struct WorkoutScreen: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query private var users: [User]
+    @State private var viewModel: WorkoutViewModel
+    @State private var isShowingExercisePicker = false
+
+    private let onDismiss: () -> Void
+
+    private var weightUnit: WeightUnit {
+        users.first?.unitPreference ?? .lbs
+    }
+
+    init(workout: Workout, onDismiss: @escaping () -> Void) {
+        _viewModel = State(wrappedValue: WorkoutViewModel(workout: workout))
+        self.onDismiss = onDismiss
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Color.prBackground.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                navBar
+                    .padding(.horizontal, PRSpacing.small)
+                    .padding(.vertical, PRSpacing.xSmall)
+
+                Divider().overlay(Color.prBorder)
+
+                mainContent
+
+                bottomBar
+            }
+        }
+        .onAppear {
+            modelContext.insert(viewModel.workout)
+            viewModel.startTimer()
+        }
+        .onDisappear { viewModel.stopTimer() }
+        .onChange(of: viewModel.phase) { _, phase in
+            if phase == .synced { onDismiss() }
+        }
+        .sheet(isPresented: $isShowingExercisePicker) {
+            ExercisePickerSheet { exercise in
+                viewModel.addExercise(exercise) { modelContext.insert($0) }
+            }
+        }
+        .confirmationDialog(
+            "No sets logged",
+            isPresented: $viewModel.isShowingEmptyWorkoutAlert,
+            titleVisibility: .visible
+        ) {
+            Button("Discard Workout", role: .destructive) {
+                viewModel.discard { modelContext.delete($0) }
+            }
+            Button("Keep Logging", role: .cancel) {}
+        } message: {
+            Text("You haven't logged any sets. Discard this workout?")
+        }
+        .confirmationDialog(
+            "Cancel workout?",
+            isPresented: $viewModel.isShowingCancelAlert,
+            titleVisibility: .visible
+        ) {
+            Button("Discard Workout", role: .destructive) {
+                viewModel.discard { modelContext.delete($0) }
+            }
+            Button("Keep Going", role: .cancel) {}
+        } message: {
+            Text("All logged sets will be lost.")
+        }
+    }
+
+    // MARK: Navigation bar
+
+    private var navBar: some View {
+        HStack {
+            Button("Cancel") { viewModel.requestCancel() }
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.prBrandLight)
+                .accessibilityIdentifier("CancelWorkoutButton")
+
+            Spacer()
+
+            Text(viewModel.workout.name ?? "Workout")
+                .font(.prHeadlineMedium)
+                .foregroundColor(.prTextPrimary)
+                .lineLimit(1)
+
+            Spacer()
+
+            Text(viewModel.formattedElapsed)
+                .font(.prDataSmall)
+                .foregroundColor(.prSuccess)
+                .monospacedDigit()
+                .accessibilityLabel("Elapsed time \(viewModel.formattedElapsed)")
+                .accessibilityIdentifier("WorkoutTimer")
+        }
+    }
+
+    // MARK: Main content
+
+    private var mainContent: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            LazyVStack(spacing: PRSpacing.small) {
+                ForEach(viewModel.sortedExercises) { workoutExercise in
+                    ExerciseSectionView(
+                        workoutExercise: workoutExercise,
+                        viewModel: viewModel,
+                        weightUnit: weightUnit
+                    )
+                }
+                addExerciseRow
+            }
+            .padding(.horizontal, PRSpacing.screenHorizontal)
+            .padding(.top, PRSpacing.small)
+            .padding(.bottom, PRSpacing.xxLarge)
+        }
+    }
+
+    // MARK: Add exercise row
+
+    private var addExerciseRow: some View {
+        Button {
+            isShowingExercisePicker = true
+        } label: {
+            HStack(spacing: PRSpacing.xxSmall) {
+                Image(systemName: "plus.circle")
+                    .font(.system(size: 18, weight: .medium))
+                    .accessibilityHidden(true)
+                Text("Add Exercise")
+                    .font(.prBody.weight(.medium))
+            }
+            .foregroundColor(.prBrand)
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .overlay(
+                RoundedRectangle(cornerRadius: PRRadius.large)
+                    .strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [6, 4]))
+                    .foregroundColor(.prBorder)
+            )
+        }
+        .accessibilityIdentifier("AddExerciseButton")
+        .accessibilityLabel("Add exercise")
+    }
+
+    // MARK: Bottom bar
+
+    private var bottomBar: some View {
+        VStack(spacing: 0) {
+            Divider().overlay(Color.prBorder)
+            PRButton(label: "Finish Workout") {
+                viewModel.requestFinish()
+            }
+            .padding(.horizontal, PRSpacing.screenHorizontal)
+            .padding(.vertical, PRSpacing.small)
+            .accessibilityIdentifier("FinishWorkoutButton")
+        }
+        .background(Color.prBackground)
+    }
+}
+
+// MARK: ExerciseSectionView
+
+private struct ExerciseSectionView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    let workoutExercise: WorkoutExercise
+    @Bindable var viewModel: WorkoutViewModel
+    let weightUnit: WeightUnit
+
+    @FocusState private var weightFocused: Bool
+    @FocusState private var repsFocused: Bool
+
+    private var exerciseName: String {
+        workoutExercise.exercise?.name ?? "Exercise"
+    }
+
+    private var unitLabel: String {
+        weightUnit == .kg ? "kg" : "lbs"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: PRSpacing.xSmall) {
+            exerciseHeader
+            if !workoutExercise.sets.isEmpty {
+                setTable
+            }
+            setInputCard
+        }
+    }
+
+    // MARK: Exercise header
+
+    private var exerciseHeader: some View {
+        HStack {
+            Text(exerciseName)
+                .font(.prHeadlineMedium)
+                .foregroundColor(.prTextPrimary)
+            Spacer()
+        }
+        .padding(.top, PRSpacing.xxSmall)
+    }
+
+    // MARK: Set table
+
+    private var setTable: some View {
+        PRCard {
+            VStack(spacing: 0) {
+                setTableHeader
+                let sorted = workoutExercise.sets.sorted { $0.setNumber < $1.setNumber }
+                ForEach(sorted) { set in
+                    setRow(set)
+                }
+            }
+        }
+    }
+
+    private var setTableHeader: some View {
+        HStack {
+            Text("#")
+                .frame(width: 28, alignment: .center)
+            Spacer()
+            Text("WEIGHT")
+                .frame(minWidth: 80, alignment: .trailing)
+            Text("REPS")
+                .frame(width: 44, alignment: .trailing)
+            Image(systemName: "checkmark")
+                .frame(width: 28, alignment: .center)
+                .accessibilityHidden(true)
+        }
+        .font(.prCaptionSmall.weight(.semibold))
+        .foregroundColor(.prTextSecondary)
+        .padding(.bottom, PRSpacing.xxSmall)
+    }
+
+    private func setRow(_ set: WorkoutSet) -> some View {
+        HStack {
+            Text("\(set.setNumber)")
+                .font(.prDataSmall)
+                .foregroundColor(.prTextSecondary)
+                .frame(width: 28, alignment: .center)
+            Spacer()
+            Text(weightDisplay(set))
+                .font(.prDataMedium)
+                .foregroundColor(.prTextPrimary)
+                .frame(minWidth: 80, alignment: .trailing)
+            Text(repsDisplay(set))
+                .font(.prDataMedium)
+                .foregroundColor(.prTextPrimary)
+                .frame(width: 44, alignment: .trailing)
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(.prSuccess)
+                .frame(width: 28, alignment: .center)
+                .accessibilityHidden(true)
+        }
+        .padding(.vertical, PRSpacing.xxxSmall)
+        .accessibilityLabel("Set \(set.setNumber): \(weightDisplay(set)), \(repsDisplay(set)) reps")
+    }
+
+    private func weightDisplay(_ set: WorkoutSet) -> String {
+        guard let w = set.weight else { return "—" }
+        let unit = set.weightUnit?.rawValue ?? ""
+        return "\(w.formatted(.number.precision(.fractionLength(0...1)))) \(unit)"
+    }
+
+    private func repsDisplay(_ set: WorkoutSet) -> String {
+        guard let r = set.reps else { return "—" }
+        return "\(r)"
+    }
+
+    // MARK: Set input card
+
+    private var setInputCard: some View {
+        PRCard {
+            VStack(spacing: PRSpacing.xSmall) {
+                setInputHeader
+                HStack(spacing: PRSpacing.xSmall) {
+                    weightField
+                    repsField
+                }
+                PRButton(label: "Log Set", variant: .primary) {
+                    viewModel.logSet(
+                        for: workoutExercise,
+                        weightUnit: weightUnit
+                    ) { set in
+                        modelContext.insert(set)
+                    }
+                }
+                .frame(height: 44)
+                .accessibilityIdentifier("LogSetButton")
+            }
+        }
+    }
+
+    private var setInputHeader: some View {
+        HStack {
+            Text("Set \(workoutExercise.sets.count + 1)")
+                .font(.prCaption.weight(.semibold))
+                .foregroundColor(.prTextSecondary)
+            Spacer()
+            if viewModel.setConfirmationExerciseID == workoutExercise.id {
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 13))
+                        .foregroundColor(.prSuccess)
+                        .accessibilityHidden(true)
+                    Text("Set saved")
+                        .font(.prCaption)
+                        .foregroundColor(.prSuccess)
+                }
+                .transition(.opacity.combined(with: .scale(scale: 0.85)))
+                .accessibilityLabel("Set saved")
+            }
+        }
+        .animation(PRAnimation.quick, value: viewModel.setConfirmationExerciseID)
+    }
+
+    private var weightField: some View {
+        VStack(alignment: .leading, spacing: PRSpacing.xxxSmall) {
+            Text("Weight (\(unitLabel))")
+                .font(.prCaptionSmall)
+                .foregroundColor(.prTextTertiary)
+            TextField("0", text: Binding(
+                get: { viewModel.weightInputs[workoutExercise.id] ?? "" },
+                set: { viewModel.weightInputs[workoutExercise.id] = $0 }
+            ))
+            .keyboardType(.decimalPad)
+            .font(.prDataMedium)
+            .multilineTextAlignment(.center)
+            .focused($weightFocused)
+            .prInputFieldStyle(isFocused: weightFocused, height: 50)
+            .accessibilityLabel("Weight in \(unitLabel)")
+            .accessibilityIdentifier("WeightInput")
+        }
+    }
+
+    private var repsField: some View {
+        VStack(alignment: .leading, spacing: PRSpacing.xxxSmall) {
+            Text("Reps")
+                .font(.prCaptionSmall)
+                .foregroundColor(.prTextTertiary)
+            TextField("0", text: Binding(
+                get: { viewModel.repsInputs[workoutExercise.id] ?? "" },
+                set: { viewModel.repsInputs[workoutExercise.id] = $0 }
+            ))
+            .keyboardType(.numberPad)
+            .font(.prDataMedium)
+            .multilineTextAlignment(.center)
+            .focused($repsFocused)
+            .prInputFieldStyle(isFocused: repsFocused, height: 50)
+            .accessibilityLabel("Number of reps")
+            .accessibilityIdentifier("RepsInput")
+        }
+    }
+}

--- a/PRLifts/PRLifts/Workout/WorkoutViewModel.swift
+++ b/PRLifts/PRLifts/Workout/WorkoutViewModel.swift
@@ -1,0 +1,167 @@
+import Foundation
+import PRLiftsCore
+
+@MainActor
+@Observable
+final class WorkoutViewModel {
+
+    // MARK: Phase
+
+    enum Phase { case active, finishing, synced }
+
+    private(set) var phase: Phase = .active
+
+    // MARK: State
+
+    let workout: Workout
+    var elapsedSeconds: Int = 0
+
+    // Keyed by WorkoutExercise.id — weight and reps input per exercise
+    var weightInputs: [UUID: String] = [:]
+    var repsInputs: [UUID: String] = [:]
+
+    // Which exercise just confirmed a saved set (auto-clears after 1.5 s)
+    private(set) var setConfirmationExerciseID: UUID? = nil
+
+    // Confirmation gate state
+    var isShowingEmptyWorkoutAlert = false
+    var isShowingCancelAlert = false
+
+    private var timerTask: Task<Void, Never>?
+
+    // MARK: Init
+
+    init(workout: Workout) {
+        self.workout = workout
+    }
+
+    // MARK: Timer
+
+    func startTimer() {
+        timerTask?.cancel()
+        let start = workout.startedAt
+        timerTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { break }
+                self?.elapsedSeconds = Int(Date().timeIntervalSince(start))
+            }
+        }
+    }
+
+    func stopTimer() {
+        timerTask?.cancel()
+        timerTask = nil
+    }
+
+    var formattedElapsed: String {
+        let h = elapsedSeconds / 3600
+        let m = (elapsedSeconds % 3600) / 60
+        let s = elapsedSeconds % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, s)
+        }
+        return String(format: "%02d:%02d", m, s)
+    }
+
+    // MARK: Exercises
+
+    func addExercise(_ exercise: Exercise, insert: (WorkoutExercise) -> Void) {
+        let we = WorkoutExercise(orderIndex: workout.exercises.count)
+        we.workout = workout
+        we.exercise = exercise
+        workout.exercises.append(we)
+        insert(we)
+        weightInputs[we.id] = ""
+        repsInputs[we.id] = ""
+    }
+
+    var sortedExercises: [WorkoutExercise] {
+        workout.exercises.sorted { $0.orderIndex < $1.orderIndex }
+    }
+
+    // MARK: Set Logging
+
+    @discardableResult
+    func logSet(
+        for workoutExercise: WorkoutExercise,
+        weightUnit: WeightUnit,
+        insert: (WorkoutSet) -> Void
+    ) -> Bool {
+        let repsStr = repsInputs[workoutExercise.id] ?? ""
+        guard let reps = Int(repsStr), reps > 0 else { return false }
+
+        let weightStr = weightInputs[workoutExercise.id] ?? ""
+        let weight = Double(weightStr)
+
+        let setNumber = workoutExercise.sets.count + 1
+        let set = WorkoutSet(
+            setNumber: setNumber,
+            weight: weight,
+            weightUnit: weight != nil ? weightUnit : nil,
+            reps: reps,
+            isCompleted: true
+        )
+        set.workoutExercise = workoutExercise
+        workoutExercise.sets.append(set)
+        insert(set)
+
+        weightInputs[workoutExercise.id] = ""
+        repsInputs[workoutExercise.id] = ""
+
+        // Brief "Set saved" confirmation — Decision 93
+        setConfirmationExerciseID = workoutExercise.id
+        Task { [weak self, exerciseID = workoutExercise.id] in
+            try? await Task.sleep(for: .milliseconds(1500))
+            if self?.setConfirmationExerciseID == exerciseID {
+                self?.setConfirmationExerciseID = nil
+            }
+        }
+
+        return true
+    }
+
+    var totalSetCount: Int {
+        workout.exercises.reduce(0) { $0 + $1.sets.count }
+    }
+
+    // MARK: Finish
+
+    func requestFinish() {
+        if totalSetCount == 0 {
+            isShowingEmptyWorkoutAlert = true
+        } else {
+            confirmFinish()
+        }
+    }
+
+    func confirmFinish() {
+        let now = Date()
+        workout.completedAt = now
+        workout.durationSeconds = max(1, Int(now.timeIntervalSince(workout.startedAt)))
+        workout.status = .completed
+        workout.updatedAt = now
+        stopTimer()
+        // V1: transition through finishing immediately (real sync queued in a later sprint)
+        phase = .finishing
+        phase = .synced
+    }
+
+    // MARK: Cancel / Discard
+
+    func requestCancel() {
+        if totalSetCount == 0 {
+            discard(delete: { _ in })
+        } else {
+            isShowingCancelAlert = true
+        }
+    }
+
+    func discard(delete: (Workout) -> Void) {
+        stopTimer()
+        delete(workout)
+        phase = .synced
+    }
+
+
+}

--- a/PRLifts/PRLiftsTests/Workout/WorkoutViewModelTests.swift
+++ b/PRLifts/PRLiftsTests/Workout/WorkoutViewModelTests.swift
@@ -1,0 +1,250 @@
+import XCTest
+import SwiftData
+import PRLiftsCore
+@testable import PRLifts
+
+@MainActor
+final class WorkoutViewModelTests: XCTestCase {
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var workout: Workout!
+    private var sut: WorkoutViewModel!
+
+    override func setUp() async throws {
+        container = try PRLiftsSchema.makeContainer(inMemory: true)
+        context = container.mainContext
+        workout = Workout(type: .adHoc, format: .weightlifting)
+        context.insert(workout)
+        try context.save()
+        sut = WorkoutViewModel(workout: workout)
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        workout = nil
+        context = nil
+        container = nil
+    }
+
+    // MARK: Helpers
+
+    /// Adds one exercise to the workout and returns the resulting WorkoutExercise.
+    @discardableResult
+    private func addWorkoutExercise() -> WorkoutExercise {
+        let exercise = Exercise(
+            name: "Squat",
+            category: .strength,
+            muscleGroup: .quads,
+            equipment: .barbell
+        )
+        context.insert(exercise)
+        sut.addExercise(exercise) { self.context.insert($0) }
+        return sut.sortedExercises.first!
+    }
+
+    // MARK: Initial state
+
+    func testInitial_phaseIsActive() {
+        XCTAssertEqual(sut.phase, .active)
+    }
+
+    func testInitial_elapsedSecondsIsZero() {
+        XCTAssertEqual(sut.elapsedSeconds, 0)
+    }
+
+    func testInitial_totalSetCountIsZero() {
+        XCTAssertEqual(sut.totalSetCount, 0)
+    }
+
+    // MARK: addExercise
+
+    func testAddExercise_appendsToWorkout() {
+        let we = addWorkoutExercise()
+        XCTAssertEqual(sut.sortedExercises.count, 1)
+        XCTAssertEqual(sut.sortedExercises.first?.id, we.id)
+    }
+
+    func testAddExercise_initializesFormState() {
+        let we = addWorkoutExercise()
+        XCTAssertEqual(sut.weightInputs[we.id], "")
+        XCTAssertEqual(sut.repsInputs[we.id], "")
+    }
+
+    // MARK: logSet
+
+    func testLogSet_withValidInput_returnsTrue() {
+        let we = addWorkoutExercise()
+        sut.weightInputs[we.id] = "100"
+        sut.repsInputs[we.id] = "5"
+        let result = sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        XCTAssertTrue(result)
+    }
+
+    func testLogSet_withEmptyReps_returnsFalse() {
+        let we = addWorkoutExercise()
+        sut.weightInputs[we.id] = "100"
+        sut.repsInputs[we.id] = ""
+        let result = sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        XCTAssertFalse(result)
+    }
+
+    func testLogSet_withZeroReps_returnsFalse() {
+        let we = addWorkoutExercise()
+        sut.repsInputs[we.id] = "0"
+        let result = sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        XCTAssertFalse(result)
+    }
+
+    func testLogSet_withNonNumericReps_returnsFalse() {
+        let we = addWorkoutExercise()
+        sut.repsInputs[we.id] = "abc"
+        let result = sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        XCTAssertFalse(result)
+    }
+
+    func testLogSet_appendsToWorkoutExercise() {
+        let we = addWorkoutExercise()
+        sut.repsInputs[we.id] = "8"
+        sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        XCTAssertEqual(we.sets.count, 1)
+    }
+
+    func testLogSet_incrementsSetNumber() {
+        let we = addWorkoutExercise()
+        sut.repsInputs[we.id] = "8"
+        sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        sut.repsInputs[we.id] = "8"
+        sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        let sorted = we.sets.sorted { $0.setNumber < $1.setNumber }
+        XCTAssertEqual(sorted[0].setNumber, 1)
+        XCTAssertEqual(sorted[1].setNumber, 2)
+    }
+
+    func testLogSet_callsInsertClosure() {
+        let we = addWorkoutExercise()
+        sut.repsInputs[we.id] = "5"
+        var inserted: [WorkoutSet] = []
+        sut.logSet(for: we, weightUnit: .lbs) { inserted.append($0) }
+        XCTAssertEqual(inserted.count, 1)
+    }
+
+    func testLogSet_clearsInputsAfterSuccess() {
+        let we = addWorkoutExercise()
+        sut.weightInputs[we.id] = "80"
+        sut.repsInputs[we.id] = "10"
+        sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        XCTAssertEqual(sut.weightInputs[we.id], "")
+        XCTAssertEqual(sut.repsInputs[we.id], "")
+    }
+
+    func testLogSet_setsConfirmationExerciseID() {
+        let we = addWorkoutExercise()
+        sut.repsInputs[we.id] = "5"
+        sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        XCTAssertEqual(sut.setConfirmationExerciseID, we.id)
+    }
+
+    func testLogSet_storesWeightAndUnit() {
+        let we = addWorkoutExercise()
+        sut.weightInputs[we.id] = "60"
+        sut.repsInputs[we.id] = "12"
+        sut.logSet(for: we, weightUnit: .kg) { context.insert($0) }
+        let set = we.sets.first!
+        XCTAssertEqual(set.weight, 60)
+        XCTAssertEqual(set.weightUnit, .kg)
+    }
+
+    func testLogSet_nilWeightUnit_whenNoWeight() {
+        let we = addWorkoutExercise()
+        sut.weightInputs[we.id] = ""
+        sut.repsInputs[we.id] = "10"
+        sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        XCTAssertNil(we.sets.first?.weightUnit)
+    }
+
+    func testLogSet_incrementsTotalSetCount() {
+        let we = addWorkoutExercise()
+        sut.repsInputs[we.id] = "5"
+        sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        XCTAssertEqual(sut.totalSetCount, 1)
+    }
+
+    // MARK: requestFinish / confirmFinish
+
+    func testRequestFinish_withNoSets_showsEmptyAlert() {
+        sut.requestFinish()
+        XCTAssertTrue(sut.isShowingEmptyWorkoutAlert)
+    }
+
+    func testRequestFinish_withSets_transitionsToSynced() {
+        let we = addWorkoutExercise()
+        sut.repsInputs[we.id] = "5"
+        sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        sut.requestFinish()
+        XCTAssertEqual(sut.phase, .synced)
+    }
+
+    func testConfirmFinish_setsStatusCompleted() {
+        sut.confirmFinish()
+        XCTAssertEqual(workout.status, .completed)
+    }
+
+    func testConfirmFinish_setsDurationSeconds() {
+        sut.confirmFinish()
+        XCTAssertNotNil(workout.durationSeconds)
+        XCTAssertGreaterThan(workout.durationSeconds ?? 0, 0)
+    }
+
+    func testConfirmFinish_setsCompletedAt() {
+        sut.confirmFinish()
+        XCTAssertNotNil(workout.completedAt)
+    }
+
+    func testConfirmFinish_transitionsToSynced() {
+        sut.confirmFinish()
+        XCTAssertEqual(sut.phase, .synced)
+    }
+
+    // MARK: requestCancel / discard
+
+    func testRequestCancel_withNoSets_transitionsToSynced() {
+        sut.requestCancel()
+        XCTAssertEqual(sut.phase, .synced)
+    }
+
+    func testRequestCancel_withSets_showsCancelAlert() {
+        let we = addWorkoutExercise()
+        sut.repsInputs[we.id] = "5"
+        sut.logSet(for: we, weightUnit: .lbs) { context.insert($0) }
+        sut.requestCancel()
+        XCTAssertTrue(sut.isShowingCancelAlert)
+    }
+
+    func testDiscard_callsDeleteClosure() {
+        var deleted: [Workout] = []
+        sut.discard { deleted.append($0) }
+        XCTAssertEqual(deleted.count, 1)
+        XCTAssertEqual(deleted.first?.id, workout.id)
+    }
+
+    func testDiscard_transitionsToSynced() {
+        sut.discard { _ in }
+        XCTAssertEqual(sut.phase, .synced)
+    }
+
+    // MARK: formattedElapsed
+
+    func testFormattedElapsed_underOneHour() {
+        sut.elapsedSeconds = 125
+        XCTAssertEqual(sut.formattedElapsed, "02:05")
+    }
+
+    func testFormattedElapsed_overOneHour() {
+        sut.elapsedSeconds = 3661
+        XCTAssertEqual(sut.formattedElapsed, "1:01:01")
+    }
+
+    func testFormattedElapsed_zero() {
+        XCTAssertEqual(sut.formattedElapsed, "00:00")
+    }
+}

--- a/PRLifts/PRLiftsUITests/Home/HomeScreenUITests.swift
+++ b/PRLifts/PRLiftsUITests/Home/HomeScreenUITests.swift
@@ -80,15 +80,15 @@ final class HomeScreenUITests: XCTestCase {
 
     // MARK: Start Workout interaction
 
-    func testHomeScreen_startWorkoutButton_showsComingSoonAlert() {
+    func testHomeScreen_startWorkoutButton_presentsWorkoutScreen() {
         app.buttons["Start Workout"].tap()
-        XCTAssertTrue(app.alerts["Coming Soon"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["FinishWorkoutButton"].waitForExistence(timeout: 3))
     }
 
-    func testHomeScreen_comingSoonAlert_dismissesOnOK() {
+    func testHomeScreen_workoutScreen_cancelWithNoSets_dismisses() {
         app.buttons["Start Workout"].tap()
-        XCTAssertTrue(app.alerts["Coming Soon"].waitForExistence(timeout: 3))
-        app.alerts["Coming Soon"].buttons["OK"].tap()
-        XCTAssertFalse(app.alerts["Coming Soon"].exists)
+        XCTAssertTrue(app.buttons["FinishWorkoutButton"].waitForExistence(timeout: 3))
+        app.buttons["CancelWorkoutButton"].tap()
+        XCTAssertTrue(app.staticTexts["PRLifts"].waitForExistence(timeout: 3))
     }
 }

--- a/PRLifts/PRLiftsUITests/Workout/WorkoutScreenUITests.swift
+++ b/PRLifts/PRLiftsUITests/Workout/WorkoutScreenUITests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+final class WorkoutScreenUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["UITesting", "SkipOnboarding"]
+        app.launch()
+    }
+
+    private func openWorkoutScreen() {
+        app.buttons["Start Workout"].tap()
+        XCTAssertTrue(app.buttons["FinishWorkoutButton"].waitForExistence(timeout: 3))
+    }
+
+    // MARK: Presentation
+
+    func testWorkoutScreen_isPresented_whenStartWorkoutTapped() {
+        openWorkoutScreen()
+        XCTAssertTrue(app.buttons["FinishWorkoutButton"].exists)
+    }
+
+    func testWorkoutScreen_showsTimer() {
+        openWorkoutScreen()
+        XCTAssertTrue(
+            app.staticTexts.matching(identifier: "WorkoutTimer").firstMatch.waitForExistence(timeout: 3)
+        )
+    }
+
+    func testWorkoutScreen_showsAddExerciseButton() {
+        openWorkoutScreen()
+        XCTAssertTrue(app.buttons["AddExerciseButton"].waitForExistence(timeout: 3))
+    }
+
+    // MARK: Cancel
+
+    func testWorkoutScreen_cancelWithNoSets_dismisses() {
+        openWorkoutScreen()
+        app.buttons["CancelWorkoutButton"].tap()
+        XCTAssertTrue(app.staticTexts["PRLifts"].waitForExistence(timeout: 3))
+    }
+
+    // MARK: Add Exercise
+
+    func testWorkoutScreen_addExercise_showsPicker() {
+        openWorkoutScreen()
+        app.buttons["AddExerciseButton"].tap()
+        XCTAssertTrue(app.staticTexts["Add Exercise"].waitForExistence(timeout: 3))
+    }
+
+    // MARK: Finish with no sets
+
+    func testWorkoutScreen_finishWithNoSets_showsConfirmationDialog() {
+        openWorkoutScreen()
+        app.buttons["FinishWorkoutButton"].tap()
+        XCTAssertTrue(app.sheets.staticTexts["No sets logged"].waitForExistence(timeout: 3))
+    }
+
+    func testWorkoutScreen_finishWithNoSets_discardReturnsHome() {
+        openWorkoutScreen()
+        app.buttons["FinishWorkoutButton"].tap()
+        XCTAssertTrue(app.sheets.buttons["Discard Workout"].waitForExistence(timeout: 3))
+        app.sheets.buttons["Discard Workout"].tap()
+        XCTAssertTrue(app.staticTexts["PRLifts"].waitForExistence(timeout: 3))
+    }
+}


### PR DESCRIPTION
## Summary

- Implements full active workout flow: HomeScreen → WorkoutScreen via `.sheet(item:)`
- `WorkoutViewModel` drives all state: exercise list, set inputs, timer, phase machine (active → finishing → synced)
- `ExercisePickerSheet` with local library + remote search fallback (400ms debounce, stub service)
- `WorkoutScreen` and `ExerciseSectionView` handle set entry (weight + reps), immediate SwiftData persistence via closure injection, and Decision 93 "Set saved" confirmation (1500ms auto-clear)
- Finish Workout: empty-set confirmation dialog, then completes and dismisses; Cancel: immediate discard if no sets, confirmation otherwise

## Technical notes

- Chose `.sheet(item:)` over `.fullScreenCover` — iOS 26 silently drops `fullScreenCover` presentations inside `TabView` when the content closure returns nil due to state-update ordering; `sheet(item:)` avoids this entirely
- `modelContext.insert(workout)` moved to `WorkoutScreen.onAppear` (not button action) to prevent SwiftData notification from interfering with SwiftUI state batching
- Removed `.accessibilityIdentifier("WorkoutScreen")` from ZStack root — iOS 26 propagates container identifiers over child element identifiers outside ScrollView boundaries; individual element identifiers now work correctly

## Test plan

- [x] 28 `WorkoutViewModelTests` unit tests — all pass
- [x] 7 `WorkoutScreenUITests` UI tests — all pass on iPhone SE (UDID `6C107B89-D600-4A9E-81BA-3606168CD8A3`)
- [x] `HomeScreenUITests` — "Coming Soon" tests replaced with workout presentation tests, all pass
- [x] Full `PRLiftsWeeklyTests` test plan — 0 failures
- [x] Pre-commit hook passed (xcodebuild + ruff + pip-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)