### PR TITLE
Add canonical URL to privacy policy

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,7 @@
 # PRLifts Privacy Policy
 
-**Last Updated:** 2026-05-12
+**Last Updated:** 2026-05-12  
+**Canonical URL:** https://tigersabre.github.io/prlifts/privacy-policy
 
 PRLifts ("we", "us", "our") is a fitness tracking application. This policy explains
 what personal data we collect, how we use it, and what rights you have over it.


### PR DESCRIPTION
## Summary

- Enables GitHub Pages on this repo (source: `main` branch, `/docs` folder) via the GitHub API
- Adds `**Canonical URL:** https://tigersabre.github.io/prlifts/privacy-policy` near the top of `docs/privacy-policy.md`

The privacy policy is now live (or will be within a few minutes of merge) at the canonical URL above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)