### PR TITLE
Switch JWT verification to ES256/JWKS with HS256 fallback

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -6,6 +6,10 @@ FastAPI dependency for Supabase JWT authentication. get_current_user is the
 single entry point for protected routes — add it as a Depends() parameter to
 any route that requires a signed-in user.
 
+Verifies ES256 tokens via Supabase's JWKS endpoint (1-hour TTL cache). Falls
+back to HS256 with SUPABASE_JWT_SECRET for legacy tokens when the secret is
+set and the token algorithm is not ES256.
+
 The JWT value is never logged at any level. Only the resolved user_id is logged
 on successful authentication. See docs/STANDARDS.md § 2.2 Hard Rules.
 See docs/ERROR_CATALOG.md — Auth Errors for all error codes used here.
@@ -20,12 +24,14 @@ import jwt
 from fastapi import HTTPException, Request, status
 
 from app.config import get_settings
+from app.jwks import get_public_key
 from app.schemas import ErrorResponse
 
 logger = logging.getLogger(__name__)
 
-_ALGORITHM = "HS256"
 _AUDIENCE = "authenticated"
+_MSG_EXPIRED = "Your session has expired. Please sign in again."
+_MSG_INVALID = "Your session has expired. Please sign in again."
 
 
 @dataclass(frozen=True)
@@ -42,17 +48,6 @@ class AuthenticatedUser:
 
 
 def _raise_401(error_code: str, message: str, correlation_id: str) -> NoReturn:
-    """
-    Raises HTTP 401 with a standard ErrorResponse body.
-
-    Args:
-        error_code: Machine-readable code from docs/ERROR_CATALOG.md.
-        message: User-safe message. Never include internal details.
-        correlation_id: Request correlation ID for support queries.
-
-    Raises:
-        HTTPException: Always — HTTP 401 with the error body.
-    """
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail=ErrorResponse(
@@ -63,14 +58,53 @@ def _raise_401(error_code: str, message: str, correlation_id: str) -> NoReturn:
     )
 
 
+async def _verify_es256(token: str, kid: str, correlation_id: str) -> dict[str, object]:
+    """Decodes an ES256 token using the matching public key from JWKS."""
+    public_key = await get_public_key(kid)
+    if public_key is None:
+        _raise_401("auth_token_invalid", _MSG_INVALID, correlation_id)
+    try:
+        return jwt.decode(
+            token,
+            public_key,
+            algorithms=["ES256"],
+            audience=_AUDIENCE,
+        )
+    except jwt.ExpiredSignatureError:
+        _raise_401("auth_token_expired", _MSG_EXPIRED, correlation_id)
+    except jwt.InvalidTokenError:
+        _raise_401("auth_token_invalid", _MSG_INVALID, correlation_id)
+
+
+def _verify_hs256(token: str, correlation_id: str) -> dict[str, object]:
+    """Decodes an HS256 token using SUPABASE_JWT_SECRET."""
+    secret = get_settings().supabase_jwt_secret
+    if not secret:
+        _raise_401("auth_token_invalid", _MSG_INVALID, correlation_id)
+    try:
+        return jwt.decode(
+            token,
+            secret,
+            algorithms=["HS256"],
+            audience=_AUDIENCE,
+        )
+    except jwt.ExpiredSignatureError:
+        _raise_401("auth_token_expired", _MSG_EXPIRED, correlation_id)
+    except jwt.InvalidTokenError:
+        _raise_401("auth_token_invalid", _MSG_INVALID, correlation_id)
+
+
 async def get_current_user(request: Request) -> AuthenticatedUser:
     """
-    FastAPI dependency that validates a Supabase JWT and returns the caller's identity.
+    FastAPI dependency that validates a Supabase JWT and returns the caller's
+    identity.
 
-    Reads Authorization: Bearer <token>, decodes with SUPABASE_JWT_SECRET using
-    HS256, and returns the authenticated user from the token claims.
+    Verifies ES256 tokens via the Supabase JWKS endpoint (1-hour TTL cache).
+    Falls back to HS256 with SUPABASE_JWT_SECRET when the secret is set and
+    the token algorithm is not ES256.
 
-    The raw JWT is never logged — only the resolved user_id is emitted on success.
+    The raw JWT is never logged — only the resolved user_id is emitted on
+    success.
 
     Args:
         request: The incoming FastAPI request.
@@ -79,10 +113,10 @@ async def get_current_user(request: Request) -> AuthenticatedUser:
         AuthenticatedUser with the validated user id and role.
 
     Raises:
-        HTTPException 401 auth_token_missing: No Authorization header present.
-        HTTPException 401 auth_token_expired: JWT is past its expiry time.
-        HTTPException 401 auth_token_invalid: Signature invalid, malformed token,
-            bad audience, or sub claim missing/non-UUID.
+        HTTPException 401 auth_token_missing: No Authorization header.
+        HTTPException 401 auth_token_expired: JWT past its expiry time.
+        HTTPException 401 auth_token_invalid: Bad signature, malformed token,
+            wrong audience, or sub claim missing/non-UUID.
     """
     correlation_id: str = getattr(request.state, "correlation_id", "")
 
@@ -91,45 +125,30 @@ async def get_current_user(request: Request) -> AuthenticatedUser:
         _raise_401("auth_token_missing", "Authentication required.", correlation_id)
 
     token = auth_header.removeprefix("Bearer ")
-    secret = get_settings().supabase_jwt_secret
 
     try:
-        payload: dict[str, object] = jwt.decode(
-            token,
-            secret,
-            algorithms=[_ALGORITHM],
-            audience=_AUDIENCE,
-        )
-    except jwt.ExpiredSignatureError:
-        # Caught before InvalidTokenError because ExpiredSignatureError is a subclass.
-        _raise_401(
-            "auth_token_expired",
-            "Your session has expired. Please sign in again.",
-            correlation_id,
-        )
+        unverified_header = jwt.get_unverified_header(token)
     except jwt.InvalidTokenError:
-        _raise_401(
-            "auth_token_invalid",
-            "Your session has expired. Please sign in again.",
-            correlation_id,
-        )
+        _raise_401("auth_token_invalid", _MSG_INVALID, correlation_id)
+
+    alg: str = unverified_header.get("alg", "")
+    kid: str = unverified_header.get("kid", "")
+
+    if alg == "ES256":
+        if not kid:
+            _raise_401("auth_token_invalid", _MSG_INVALID, correlation_id)
+        payload: dict[str, object] = await _verify_es256(token, kid, correlation_id)
+    else:
+        payload = _verify_hs256(token, correlation_id)
 
     sub = payload.get("sub")
     if not isinstance(sub, str) or not sub:
-        _raise_401(
-            "auth_token_invalid",
-            "Your session has expired. Please sign in again.",
-            correlation_id,
-        )
+        _raise_401("auth_token_invalid", _MSG_INVALID, correlation_id)
 
     try:
         user_id = UUID(sub)
     except ValueError:
-        _raise_401(
-            "auth_token_invalid",
-            "Your session has expired. Please sign in again.",
-            correlation_id,
-        )
+        _raise_401("auth_token_invalid", _MSG_INVALID, correlation_id)
 
     role: str = str(payload.get("role", _AUDIENCE))
 

--- a/backend/app/jwks.py
+++ b/backend/app/jwks.py
@@ -1,0 +1,91 @@
+"""
+jwks.py
+PRLifts Backend
+
+JWKS key cache for ES256 JWT verification against Supabase's asymmetric
+signing keys. Fetches and caches the Supabase JWKS endpoint with a 1-hour TTL.
+On a kid miss against a fresh cache, refetches once to handle key rotation.
+"""
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import jwt
+
+logger = logging.getLogger(__name__)
+
+_JWKS_URL = "https://kgrwxdmmycqdongqewzr.supabase.co/auth/v1/.well-known/jwks.json"
+_TTL = timedelta(hours=1)
+_FETCH_TIMEOUT = httpx.Timeout(10.0)
+
+
+class JWKSCache:
+    """In-process cache of Supabase EC public keys keyed by kid."""
+
+    def __init__(self) -> None:
+        self._keys: dict[str, Any] = {}
+        self._fetched_at: datetime | None = None
+        self._lock = asyncio.Lock()
+
+    def _is_stale(self) -> bool:
+        if self._fetched_at is None:
+            return True
+        return datetime.now(UTC) - self._fetched_at >= _TTL
+
+    async def _fetch(self) -> None:
+        """Fetches the JWKS endpoint and repopulates the key cache."""
+        logger.info("Fetching JWKS from Supabase")
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(_JWKS_URL, timeout=_FETCH_TIMEOUT)
+            resp.raise_for_status()
+            data: dict[str, Any] = resp.json()
+
+        new_keys: dict[str, Any] = {}
+        for jwk in data.get("keys", []):
+            kid: str = jwk.get("kid", "")
+            if not kid:
+                continue
+            try:
+                new_keys[kid] = jwt.algorithms.ECAlgorithm.from_jwk(jwk)
+            except Exception:
+                logger.warning("Failed to parse JWK", extra={"kid": kid})
+
+        self._keys = new_keys
+        self._fetched_at = datetime.now(UTC)
+        logger.info("JWKS cache refreshed", extra={"key_count": len(new_keys)})
+
+    async def get_key(self, kid: str) -> Any | None:
+        """
+        Returns the public key for kid.
+
+        Fetches if the cache is stale. On a kid miss against a fresh cache,
+        refetches once to handle key rotation before returning None.
+
+        Args:
+            kid: The key ID from the JWT header.
+
+        Returns:
+            EC public key, or None if kid is not found after one refetch.
+        """
+        async with self._lock:
+            if self._is_stale():
+                await self._fetch()
+
+            if kid in self._keys:
+                return self._keys[kid]
+
+            # kid not in a fresh cache — refetch once for key rotation
+            await self._fetch()
+            return self._keys.get(kid)
+
+
+# Module-level singleton shared across all requests.
+_cache = JWKSCache()
+
+
+async def get_public_key(kid: str) -> Any | None:
+    """Returns the EC public key for kid, or None after one refetch."""
+    return await _cache.get_key(kid)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,8 +8,10 @@ asyncpg==0.31.0
 boolean.py==5.0
 CacheControl==0.14.4
 certifi==2026.4.22
+cffi==2.0.0
 charset-normalizer==3.4.7
 click==8.3.3
+cryptography==48.0.0
 coverage==7.13.5
 cyclonedx-python-lib==11.7.0
 defusedxml==0.7.1
@@ -32,6 +34,7 @@ mypy_extensions==1.1.0
 packageurl-python==0.17.6
 packaging==26.2
 pathspec==1.1.0
+pycparser==3.0
 pip-api==0.0.34
 pip-requirements-parser==32.0.1
 pip_audit==2.10.0

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -3,22 +3,24 @@ test_auth.py
 PRLifts Backend Tests
 
 Unit tests for app/auth.py: all four JWT validation scenarios defined in
-docs/ERROR_CATALOG.md, credential safety (JWT value never in logs), and the
-shared ErrorResponse schema.
+docs/ERROR_CATALOG.md, credential safety (JWT value never in logs), the
+shared ErrorResponse schema, and ES256/JWKS verification.
 
 get_current_user is tested by calling it directly as an async function with
 a minimal mock Request — no HTTP round-trip needed for these unit tests.
+ES256 tests patch app.auth.get_public_key to avoid network calls.
 """
 
 import logging
 import os
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
 import jwt
 import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
 from fastapi import HTTPException
 
 
@@ -333,3 +335,155 @@ def test_error_response_serialises_all_fields() -> None:
         "message": "Authentication required.",
         "request_id": "abc-123",
     }
+
+
+# ── ES256 / JWKS verification ─────────────────────────────────────────────────
+
+_EC_PRIVATE_KEY = ec.generate_private_key(ec.SECP256R1())
+_EC_PUBLIC_KEY = _EC_PRIVATE_KEY.public_key()
+_TEST_KID = "test-ec-key-id"
+
+
+def _make_es256_token(
+    *,
+    user_id: str | None = _TEST_USER_ID,
+    expired: bool = False,
+    audience: str = _AUDIENCE,
+    kid: str = _TEST_KID,
+) -> str:
+    now = datetime.now(UTC)
+    exp = now - timedelta(hours=1) if expired else now + timedelta(hours=1)
+    payload: dict[str, Any] = {"exp": exp, "aud": audience, "role": "authenticated"}
+    if user_id is not None:
+        payload["sub"] = user_id
+    return jwt.encode(
+        payload,
+        _EC_PRIVATE_KEY,
+        algorithm="ES256",
+        headers={"kid": kid},
+    )
+
+
+async def test_es256_valid_token_returns_authenticated_user() -> None:
+    from app.auth import AuthenticatedUser, get_current_user
+
+    token = _make_es256_token()
+    request = _make_request(authorization=f"Bearer {token}")
+
+    with __import__("unittest.mock", fromlist=["patch"]).patch(
+        "app.auth.get_public_key", AsyncMock(return_value=_EC_PUBLIC_KEY)
+    ):
+        user = await get_current_user(request)
+
+    assert isinstance(user, AuthenticatedUser)
+    assert user.id == UUID(_TEST_USER_ID)
+    assert user.role == "authenticated"
+
+
+async def test_es256_user_id_matches_sub_claim() -> None:
+    from app.auth import get_current_user
+
+    other_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    token = _make_es256_token(user_id=other_id)
+    request = _make_request(authorization=f"Bearer {token}")
+
+    with __import__("unittest.mock", fromlist=["patch"]).patch(
+        "app.auth.get_public_key", AsyncMock(return_value=_EC_PUBLIC_KEY)
+    ):
+        user = await get_current_user(request)
+
+    assert user.id == UUID(other_id)
+
+
+async def test_es256_expired_token_raises_auth_token_expired() -> None:
+    from app.auth import get_current_user
+
+    token = _make_es256_token(expired=True)
+    request = _make_request(authorization=f"Bearer {token}")
+
+    with __import__("unittest.mock", fromlist=["patch"]).patch(
+        "app.auth.get_public_key", AsyncMock(return_value=_EC_PUBLIC_KEY)
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+    assert _detail(exc_info.value)["error_code"] == "auth_token_expired"
+
+
+async def test_es256_unknown_kid_raises_auth_token_invalid() -> None:
+    """get_public_key returns None (kid not in JWKS after refetch) → 401."""
+    from app.auth import get_current_user
+
+    token = _make_es256_token()
+    request = _make_request(authorization=f"Bearer {token}")
+
+    with __import__("unittest.mock", fromlist=["patch"]).patch(
+        "app.auth.get_public_key", AsyncMock(return_value=None)
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+    assert _detail(exc_info.value)["error_code"] == "auth_token_invalid"
+
+
+async def test_es256_missing_kid_raises_auth_token_invalid() -> None:
+    """ES256 token with no kid header → 401 without touching JWKS."""
+    from app.auth import get_current_user
+
+    # Encode without a kid header
+    now = datetime.now(UTC)
+    payload = {
+        "sub": _TEST_USER_ID,
+        "exp": now + timedelta(hours=1),
+        "aud": _AUDIENCE,
+        "role": "authenticated",
+    }
+    token = jwt.encode(payload, _EC_PRIVATE_KEY, algorithm="ES256")
+    request = _make_request(authorization=f"Bearer {token}")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+    assert _detail(exc_info.value)["error_code"] == "auth_token_invalid"
+
+
+async def test_es256_wrong_key_raises_auth_token_invalid() -> None:
+    """Token signed with one key but verified with a different key → 401."""
+    from app.auth import get_current_user
+
+    other_private_key = ec.generate_private_key(ec.SECP256R1())
+    other_public_key = other_private_key.public_key()
+
+    token = _make_es256_token()
+    request = _make_request(authorization=f"Bearer {token}")
+
+    with __import__("unittest.mock", fromlist=["patch"]).patch(
+        "app.auth.get_public_key", AsyncMock(return_value=other_public_key)
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+    assert _detail(exc_info.value)["error_code"] == "auth_token_invalid"
+
+
+async def test_es256_never_logs_jwt_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from app.auth import get_current_user
+
+    token = _make_es256_token()
+    request = _make_request(authorization=f"Bearer {token}")
+
+    with __import__("unittest.mock", fromlist=["patch"]).patch(
+        "app.auth.get_public_key", AsyncMock(return_value=_EC_PUBLIC_KEY)
+    ):
+        with caplog.at_level(logging.DEBUG):
+            await get_current_user(request)
+
+    for record in caplog.records:
+        assert token not in record.getMessage()
+        assert token not in str(record.__dict__)

--- a/backend/tests/test_jwks.py
+++ b/backend/tests/test_jwks.py
@@ -1,0 +1,192 @@
+"""
+test_jwks.py
+PRLifts Backend Tests
+
+Unit tests for app/jwks.py: cache staleness, key lookup, and the
+single-refetch behaviour on a kid miss.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.jwks import _TTL, JWKSCache
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_KID_A = "key-id-a"
+_KID_B = "key-id-b"
+_FAKE_KEY_A = object()
+_FAKE_KEY_B = object()
+
+
+def _make_cache(
+    *,
+    keys: dict[str, Any] | None = None,
+    fetched_at: datetime | None = None,
+) -> JWKSCache:
+    """Returns a JWKSCache pre-seeded with the given state."""
+    cache = JWKSCache()
+    cache._keys = keys or {}
+    cache._fetched_at = fetched_at
+    return cache
+
+
+def _fresh_ts() -> datetime:
+    return datetime.now(UTC) - timedelta(minutes=30)
+
+
+def _stale_ts() -> datetime:
+    return datetime.now(UTC) - (_TTL + timedelta(seconds=1))
+
+
+def _mock_fetch(cache: JWKSCache, keys: dict[str, Any]) -> AsyncMock:
+    """Patches cache._fetch to populate keys without hitting the network."""
+
+    async def _fake_fetch() -> None:
+        cache._keys = keys
+        cache._fetched_at = datetime.now(UTC)
+
+    return AsyncMock(side_effect=_fake_fetch)
+
+
+# ── Staleness ─────────────────────────────────────────────────────────────────
+
+
+def test_is_stale_returns_true_when_never_fetched() -> None:
+    cache = _make_cache()
+    assert cache._is_stale() is True
+
+
+def test_is_stale_returns_false_within_ttl() -> None:
+    cache = _make_cache(fetched_at=_fresh_ts())
+    assert cache._is_stale() is False
+
+
+def test_is_stale_returns_true_after_ttl_elapses() -> None:
+    cache = _make_cache(fetched_at=_stale_ts())
+    assert cache._is_stale() is True
+
+
+# ── get_key: cache hit on fresh cache ─────────────────────────────────────────
+
+
+async def test_get_key_returns_key_without_refetch_when_fresh_and_present() -> None:
+    cache = _make_cache(keys={_KID_A: _FAKE_KEY_A}, fetched_at=_fresh_ts())
+    fetch_mock = _mock_fetch(cache, {_KID_A: _FAKE_KEY_A})
+    cache._fetch = fetch_mock  # type: ignore[method-assign]
+
+    result = await cache.get_key(_KID_A)
+
+    assert result is _FAKE_KEY_A
+    fetch_mock.assert_not_called()
+
+
+# ── get_key: stale cache triggers one fetch ───────────────────────────────────
+
+
+async def test_get_key_fetches_when_cache_is_stale() -> None:
+    cache = _make_cache(fetched_at=_stale_ts())
+    fetch_mock = _mock_fetch(cache, {_KID_A: _FAKE_KEY_A})
+    cache._fetch = fetch_mock  # type: ignore[method-assign]
+
+    result = await cache.get_key(_KID_A)
+
+    assert result is _FAKE_KEY_A
+    assert fetch_mock.call_count == 1
+
+
+# ── get_key: kid miss on fresh cache triggers one refetch ─────────────────────
+
+
+async def test_get_key_refetches_once_on_kid_miss_against_fresh_cache() -> None:
+    cache = _make_cache(keys={_KID_A: _FAKE_KEY_A}, fetched_at=_fresh_ts())
+    fetch_mock = _mock_fetch(cache, {_KID_A: _FAKE_KEY_A, _KID_B: _FAKE_KEY_B})
+    cache._fetch = fetch_mock  # type: ignore[method-assign]
+
+    result = await cache.get_key(_KID_B)
+
+    assert result is _FAKE_KEY_B
+    assert fetch_mock.call_count == 1
+
+
+async def test_get_key_returns_none_when_kid_absent_after_refetch() -> None:
+    cache = _make_cache(keys={_KID_A: _FAKE_KEY_A}, fetched_at=_fresh_ts())
+    fetch_mock = _mock_fetch(cache, {_KID_A: _FAKE_KEY_A})
+    cache._fetch = fetch_mock  # type: ignore[method-assign]
+
+    result = await cache.get_key(_KID_B)
+
+    assert result is None
+    assert fetch_mock.call_count == 1
+
+
+# ── _fetch: parses JWK keys ───────────────────────────────────────────────────
+
+
+async def test_fetch_populates_keys_from_jwks_response() -> None:
+    """Verifies _fetch stores parsed public keys keyed by kid."""
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    import jwt as _jwt
+
+    jwk_dict = json.loads(_jwt.algorithms.ECAlgorithm.to_jwk(private_key.public_key()))
+    jwk_dict["kid"] = "my-test-kid"
+    jwk_dict["use"] = "sig"
+
+    fake_response = MagicMock()
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json.return_value = {"keys": [jwk_dict]}
+
+    cache = JWKSCache()
+    with patch("app.jwks.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=fake_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        await cache._fetch()
+
+    assert "my-test-kid" in cache._keys
+    assert cache._fetched_at is not None
+
+
+async def test_fetch_skips_keys_without_kid() -> None:
+    fake_response = MagicMock()
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json.return_value = {"keys": [{"kty": "EC"}]}  # no kid
+
+    cache = JWKSCache()
+    with patch("app.jwks.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=fake_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        await cache._fetch()
+
+    assert cache._keys == {}
+
+
+async def test_fetch_skips_unparseable_keys() -> None:
+    fake_response = MagicMock()
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json.return_value = {
+        "keys": [{"kid": "bad-key", "kty": "EC", "crv": "INVALID"}]
+    }
+
+    cache = JWKSCache()
+    with patch("app.jwks.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=fake_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        await cache._fetch()
+
+    assert cache._keys == {}


### PR DESCRIPTION
## Summary
- Adds `app/jwks.py`: in-process JWKS cache (1-hour TTL) that fetches Supabase's public key endpoint and parses EC keys by `kid`. On a `kid` miss against a fresh cache, refetches once before rejecting — handles key rotation without downtime.
- Updates `app/auth.py`: inspects the token's `alg` header to dispatch — ES256 tokens go through JWKS, all others fall back to HS256 + `SUPABASE_JWT_SECRET` if present. No code changes to routers or rate-limit middleware.
- Adds `cryptography==48.0.0` (+ `cffi`, `pycparser`) to `requirements.txt` — required for PyJWT EC operations.

## Why
Supabase projects created after Oct 2025 use ES256 asymmetric signing by default. The previous HS256-only verifier rejected every token from the production project.

## Test plan
- [ ] 7 new ES256 tests in `test_auth.py` (valid token, sub extraction, expired, unknown kid, missing kid, wrong key, log safety)
- [ ] 10 new JWKS cache unit tests in `test_jwks.py` (staleness, hit/miss, refetch-once, `_fetch` JWK parsing)
- [ ] All 13 original HS256 tests still pass (verified — existing tests route through the HS256 fallback since `SUPABASE_JWT_SECRET` is set in the test env)
- [ ] 385 passed, 97.47% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)